### PR TITLE
[💡 Feature]: Allow to switch background images by clicking on them

### DIFF
--- a/packages/gui/src/dialogs/ThemeDialog.tsx
+++ b/packages/gui/src/dialogs/ThemeDialog.tsx
@@ -23,16 +23,8 @@ const useStyles = makeStyles(() => ({
   selectedButton: {
     color: "var(--vscode-foreground)",
     border: "1px solid var(--vscode-button-foreground)",
-  },
-  notSelectedButton: {
-    color: "var(--vscode-foreground)",
-    border: "1px solid var(--vscode-button-background)",
-  },
+  }
 }));
-
-interface ThemeButtonProps {
-  tile: Theme
-}
 
 interface TileStyle {
   minHeight: string
@@ -44,30 +36,10 @@ interface TileStyle {
   backgroundPositionY: string
 }
 
-let ThemeButton = React.memo(({ tile }: ThemeButtonProps) => {
-  const classes = useStyles();
-  const { setBackground, background } = useContext(GlobalContext);
-  const selected = !isNaN(+background) && tile.id === parseInt(background, 10);
-
-  return (
-    <Button
-      size="small"
-      variant={"outlined"}
-      onClick={() => setBackground(tile.id.toString()) }
-      className={selected ? classes.selectedButton : classes.notSelectedButton}
-    >
-      {selected ? (
-        <Typography style={{ fontWeight: "bold" }}>Selected</Typography>
-      ) : (
-        <Typography>Select</Typography>
-      )}
-    </Button>
-  );
-});
-
 const ThemeDialog = React.memo(({ close }: { close: () => void }) => {
   const classes = useStyles();
-  const { themeColor } = useContext(GlobalContext);
+  const { themeColor, background, setBackground } = useContext(GlobalContext);
+  const isSelected = (tile: Theme) => !isNaN(+background) && tile.id === parseInt(background, 10);
 
   return (
     <DialogContainer fullScreen={true}>
@@ -92,7 +64,16 @@ const ThemeDialog = React.memo(({ close }: { close: () => void }) => {
                   tileStyle.backgroundPositionY = "50%";
                 }
                 return (
-                  <Grid item xs={12} sm={6} md={4} lg={4} key={tile.id}>
+                  <Grid
+                    item
+                    style={{ cursor: 'pointer' }}
+                    xs={12}
+                    sm={6}
+                    md={4}
+                    lg={4}
+                    key={tile.id}
+                    onClick={() => setBackground(tile.id.toString())}
+                  >
                     <Grid container style={tileStyle} alignContent="flex-end">
                       <Grid item style={{ width: "100%" }}>
                         <Grid
@@ -118,9 +99,15 @@ const ThemeDialog = React.memo(({ close }: { close: () => void }) => {
                               </Grid>
                             </Grid>
                           </Grid>
-                          <Grid item>
-                            <ThemeButton tile={tile} />
-                          </Grid>
+                          {isSelected(tile) && <Grid item>
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              className={classes.selectedButton}
+                            >
+                              <Typography style={{ fontWeight: "bold" }}>Selected</Typography>
+                            </Button>
+                          </Grid>}
                         </Grid>
                       </Grid>
                     </Grid>

--- a/packages/gui/tests/dialogs/ThemeDialog.test.tsx
+++ b/packages/gui/tests/dialogs/ThemeDialog.test.tsx
@@ -3,18 +3,22 @@ import userEvent from '@testing-library/user-event';
 import { render } from '@testing-library/react';
 
 import ThemeDialog from "../../src/dialogs/ThemeDialog";
-import { GlobalProvider } from '@vscode-marquee/utils';
+// @ts-expect-error
+import { GlobalProvider, setBackground } from '@vscode-marquee/utils';
 
 jest.mock('../../../utils/src/contexts/Global');
 jest.mock('../../src/utils/backgrounds', () => jest.fn((bg) => bg));
 
 test('should render component properly', () => {
   const close = jest.fn();
-  const { getByText } = render(
+  const { getByText, container } = render(
     <GlobalProvider>
       <ThemeDialog close={close} />
     </GlobalProvider>
   );
   userEvent.click(getByText('Close'));
   expect(close).toBeCalledTimes(1);
+
+  userEvent.click(container.querySelectorAll('.MuiTypography-body2')[7]);
+  expect(setBackground).toBeCalledWith('8');
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -81,6 +81,7 @@ function connect<T, Events = {}> (defaults: T, tangle: Client<T & Events>): Cont
      */
     const setProp = `set${(prop as string).slice(0, 1).toUpperCase()}${(prop as string).slice(1)}` as `set${Capitalize<keyof T & string>}`;
     contextValues[setProp] = ((val: any) => {
+      setPropState(val);
       tangle.broadcast({ [prop]: val } as T & Events);
       window.vscode.setState({
         ...(window.vscode.getState() || {}),


### PR DESCRIPTION
### Is your feature request related to a problem?

Currently users can switch the background image in Marquee but they need to click the "Select" button to enable it. This might be confusing as someone could expect to just click on the image.
![bug](https://user-images.githubusercontent.com/731337/152204803-5e217a5c-a2c4-4f18-9ef2-9bb38400f4d1.gif)



### Describe the solution you'd like.

Allow to switch homescreen background by just clicking on it.

### Describe alternatives you've considered.

_No response_

### Additional context

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct