### PR TITLE
[🐛 Bug]: Add a margin to the bottom of the home screen

### DIFF
--- a/packages/gui/src/Container.tsx
+++ b/packages/gui/src/Container.tsx
@@ -102,10 +102,9 @@ export const WidgetLayout = React.memo(() => {
 
   return (
     <ResponsiveReactGridLayout
-      style={{ height: "100%" }}
       cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 4 }}
       rowHeight={20}
-      onLayoutChange={(newLayout, newLayouts) => {
+      onLayoutChange={(_, newLayouts) => {
         _setCurrentModeLayout(newLayouts);
       }}
       layouts={layoutConfig}
@@ -139,13 +138,15 @@ const Container = () => {
       return theme.id === parseInt(background, 10);
     });
 
-    if (!theme || !theme.background) {
+    if (!theme || (!theme.background && !theme.backgroundColor)) {
       return NO_BACKGROUND_STYLE;
     }
 
     return {
       ...BACKGROUND_STYLE,
-      backgroundImage: `url(${backgrounds(theme.background)})`,
+      ...(theme.background
+        ? { backgroundImage: `url(${backgrounds(theme.background)})` }
+        : { backgroundColor: theme.backgroundColor })
     };
   }, [background]);
 


### PR DESCRIPTION
### VSCode Environment

Version: 1.63.2 (Universal)
Commit: 899d46d82c4c95423fb7e10e68eba52050e30ba3
Date: 2021-12-15T09:37:28.172Z
Electron: 13.5.2
Chromium: 91.0.4472.164
Node.js: 14.16.0
V8: 9.1.269.39-electron.0
OS: Darwin arm64 21.2.0

### Marquee Version

v2.0.0

### Workspace Type

Local Workspace

### What happened?

It seems we have lost the margin at the bottom of the homescreen:

![Screenshot 2022-02-01 at 09 35 47](https://user-images.githubusercontent.com/731337/151936384-a98c8729-ff4b-46bf-8906-1c15795e496e.png)



### What is your expected behavior?

Let's add a 5px margin so widgets don't directly touch the bottom of the application.

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues