### PR TITLE
[🏠 Internal]: Allow edge releases in marketplace

### DIFF
--- a/.github/scripts/updateEdgeVersion.js
+++ b/.github/scripts/updateEdgeVersion.js
@@ -1,0 +1,19 @@
+/**
+ * Currently edge releases have the following format: `3.0.0-edge.1` which
+ * is valid semver but invalid as version to be published on the marketplace
+ * (see also https://github.com/microsoft/vscode-vsce/issues/148 for context).
+ * This means that edge releases are currently not possible with the workflow
+ * we have.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const pkgPath = path.join(__dirname, '..', '..', 'package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath).toString());
+
+const newVersion = pkg.version.split('.').slice(0, 2)
+newVersion.push(Date.now());
+pkg.version = `${newVersion.join('.')}`;
+
+console.log(`Update package.json with Edge version:\n\n${JSON.stringify(pkg, null, 2)}`);
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           NODE_ENV: production
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}
       - name: Run tests
-        uses: GabrielBB/xvfb-action@v1.0
         with:
           run: yarn test
       - name: Create Changelog
@@ -100,8 +99,10 @@ jobs:
           npm version $RELEASE_VERSION
           git tag -a $RELEASE_VERSION -m "$RELEASE_VERSION"
       - name: Package Extension (Edge)
-        run: yarn vsce package $RELEASE_VERSION --pre-release --yarn --no-git-tag-version --no-update-package-json -o "./marquee-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
         if: ${{ github.event.inputs.releaseChannel == 'edge' }}
+        run: |
+          node .github/scripts/updateEdgeVersion.js
+          yarn vsce package $RELEASE_VERSION --pre-release --yarn --no-git-tag-version --no-update-package-json -o "./marquee-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
       - name: Package Extension (Stable)
         run: yarn vsce package $RELEASE_VERSION --yarn --no-git-tag-version --no-update-package-json -o "./marquee-$RELEASE_VERSION.vsix" ${{ github.event.inputs.additionalFlags }}
         if: ${{ github.event.inputs.releaseChannel == 'stable' }}


### PR DESCRIPTION
### Is your feature request related to a problem?

Currently edge releases have the following format: `3.0.0-edge.1` which is valid semver but invalid as version to be published on the marketplace (see also https://github.com/microsoft/vscode-vsce/issues/148 for context). This means that edge releases are currently not possible with the workflow we have.

### Describe the solution you'd like.

To fix this I suggest to add an additional re-packaging step to the workflow that would modify: `3.0.0-edge.1` to be `3.0.<year><month><day><hour><minute>`, so e.g. `3.0.202202221641`.

### Describe alternatives you've considered.

_No response_

### Additional context

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct