### PR TITLE
Clean up Marquee commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,129 +86,40 @@
     },
     "commands": [
       {
-        "command": "marquee.expand",
-        "title": "Open Marquee",
-        "icon": {
-          "light": "assets/expand-dark.svg",
-          "dark": "assets/expand-light.svg"
-        }
-      },
-      {
         "command": "marquee.open",
-        "title": "Open Marquee",
+        "title": "Open",
+        "category": "Marquee",
         "icon": {
           "light": "assets/marquee-light.svg",
           "dark": "assets/marquee-dark.svg"
         }
       },
       {
+        "command": "marquee.clear",
+        "category": "Marquee",
+        "title": "Clear Persistence"
+      },
+      {
         "command": "marquee.touchbar",
         "title": "Open Marquee",
-        "icon": "assets/marquee_activity_light.png"
-      },
-      {
-        "command": "marquee.todo.toggle",
-        "title": "Marquee toggle todo"
-      },
-      {
-        "command": "marquee.clear",
-        "title": "Marquee clear persistence"
-      },
-      {
-        "command": "marquee.todo.add",
-        "title": "Add to Marquee"
-      },
-      {
-        "command": "marquee.todo.addEditor",
-        "title": "Add to Todos [Marquee]"
-      },
-      {
-        "command": "marquee.snippet.add",
-        "title": "Add Selection to Snippets [Marquee]",
-        "enablement": "editorHasSelection"
-      },
-      {
-        "command": "marquee.note.add",
-        "title": "Add to Notes [Marquee]"
-      },
-      {
-        "command": "marquee.snippet.insertEditor",
-        "title": "Insert from Snippets [Marquee]",
-        "enablement": "editorTextFocus"
+        "category": "Marquee",
+        "icon": "assets/marquee_activity_light.png",
+        "enablement": "isMac"
       },
       {
         "command": "marquee.link",
         "title": "Jump to origin",
+        "category": "Marquee",
+        "enablement": "listFocus",
         "icon": {
           "light": "assets/link-dark.svg",
           "dark": "assets/link-light.svg"
         }
       },
       {
-        "command": "marquee.edit",
-        "title": "Edit"
-      },
-      {
-        "command": "marquee.snippet.insert",
-        "title": "Insert",
-        "enablement": "listFocus"
-      },
-      {
-        "command": "marquee.snippet.remove",
-        "title": "Remove",
-        "enablement": "listFocus"
-      },
-      {
-        "command": "marquee.snippet.move",
-        "title": "Move snippet to current workspace"
-      },
-      {
-        "command": "marquee.snippet.copyToClipboard",
-        "title": "Copy snippet to clipboard",
-        "enablement": "listFocus"
-      },
-      {
-        "command": "marquee.todo.move",
-        "title": "Move todo to current workspace",
-        "enablement": "listFocus"
-      },
-      {
-        "command": "marquee.note.move",
-        "title": "Move note to current workspace",
-        "enablement": "listFocus"
-      },
-      {
-        "command": "marquee.todo.archive",
-        "title": "Archive",
-        "enablement": "listFocus"
-      },
-      {
-        "command": "marquee.todo.addEmpty",
-        "title": "Create New Todo [Marquee]",
-        "icon": {
-          "light": "assets/add-dark.svg",
-          "dark": "assets/add-light.svg"
-        }
-      },
-      {
-        "command": "marquee.note.addEmpty",
-        "title": "Create New Note [Marquee]",
-        "icon": {
-          "light": "assets/add-dark.svg",
-          "dark": "assets/add-light.svg"
-        }
-      },
-      {
-        "command": "marquee.snippet.addEmpty",
-        "title": "Create New Snippet [Marquee]",
-        "icon": {
-          "light": "assets/add-dark.svg",
-          "dark": "assets/add-light.svg"
-        }
-      },
-      {
         "command": "marquee.toggleScope",
         "title": "Toggle global / workspace scope",
+        "category": "Marquee",
         "icon": {
           "light": "assets/toggle-todo-dark.svg",
           "dark": "assets/toggle-todo-light.svg"
@@ -216,17 +127,130 @@
       },
       {
         "command": "marquee.jsonExport",
-        "title": "Marquee JSON Export"
+        "category": "Marquee",
+        "title": "JSON Export"
       },
       {
         "command": "marquee.jsonImport",
-        "title": "Marquee JSON Import"
+        "category": "Marquee",
+        "title": "JSON Import"
+      },
+      {
+        "command": "marquee.edit",
+        "category": "Marquee",
+        "enablement": "listFocus",
+        "title": "Edit"
+      },
+      {
+        "command": "marquee.todo.toggle",
+        "title": "Toggle Todo",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.todo.addEditor",
+        "title": "Add Selection to Todos",
+        "category": "Marquee",
+        "enablement": "editorHasSelection"
+      },
+      {
+        "command": "marquee.todo.move",
+        "title": "Move todo to current workspace",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.todo.archive",
+        "title": "Archive",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.todo.addEmpty",
+        "title": "Create New Todo",
+        "category": "Marquee",
+        "icon": {
+          "light": "assets/add-dark.svg",
+          "dark": "assets/add-light.svg"
+        }
+      },
+      {
+        "command": "marquee.note.addEditor",
+        "title": "Add Selection to Notes",
+        "category": "Marquee",
+        "enablement": "editorHasSelection"
+      },
+      {
+        "command": "marquee.note.move",
+        "title": "Move note to current workspace",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.note.delete",
+        "title": "Delete",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.note.addEmpty",
+        "title": "Create New Note",
+        "category": "Marquee",
+        "icon": {
+          "light": "assets/add-dark.svg",
+          "dark": "assets/add-light.svg"
+        }
+      },
+      {
+        "command": "marquee.snippet.addEmpty",
+        "title": "Create New Snippet",
+        "category": "Marquee",
+        "icon": {
+          "light": "assets/add-dark.svg",
+          "dark": "assets/add-light.svg"
+        }
+      },
+      {
+        "command": "marquee.snippet.insertEditor",
+        "title": "Insert from Snippets",
+        "category": "Marquee",
+        "enablement": "editorTextFocus"
+      },
+      {
+        "command": "marquee.snippet.addEditor",
+        "title": "Add Selection to Snippets",
+        "category": "Marquee",
+        "enablement": "editorHasSelection"
+      },
+      {
+        "command": "marquee.snippet.insert",
+        "title": "Insert",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.snippet.delete",
+        "title": "Delete",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.snippet.move",
+        "title": "Move snippet to current workspace",
+        "category": "Marquee",
+        "enablement": "listFocus"
+      },
+      {
+        "command": "marquee.snippet.copyToClipboard",
+        "title": "Copy snippet to clipboard",
+        "category": "Marquee",
+        "enablement": "listFocus"
       }
     ],
     "menus": {
       "touchBar": [
         {
-          "command": "marquee.touchbar"
+          "command": "marquee.open"
         }
       ],
       "view/title": [
@@ -236,7 +260,7 @@
           "group": "navigation@0"
         },
         {
-          "command": "marquee.expand",
+          "command": "marquee.open",
           "when": "view == marquee",
           "group": "navigation@1"
         }
@@ -253,7 +277,7 @@
           "group": "1_actions@2"
         },
         {
-          "command": "marquee.snippet.remove",
+          "command": "marquee.snippet.delete",
           "when": "view == marquee && viewItem =~ /Snippet|LinkedSnippet/",
           "group": "1_actions@3"
         },
@@ -271,6 +295,16 @@
           "command": "marquee.todo.move",
           "when": "view == marquee && viewItem =~ /Todo|LinkedTodo/",
           "group": "5_copy@1"
+        },
+        {
+          "command": "marquee.edit",
+          "when": "view == marquee && viewItem =~ /Note/",
+          "group": "1_actions@1"
+        },
+        {
+          "command": "marquee.note.delete",
+          "when": "view == marquee && viewItem =~ /Note/",
+          "group": "1_actions@2"
         },
         {
           "command": "marquee.note.move",
@@ -319,11 +353,11 @@
           "group": "1_modification"
         },
         {
-          "command": "marquee.snippet.add",
+          "command": "marquee.snippet.addEditor",
           "group": "1_modification"
         },
         {
-          "command": "marquee.note.add",
+          "command": "marquee.note.addEditor",
           "group": "1_modification"
         },
         {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -112,8 +112,6 @@ export class MarqueeExtension {
     const disposables: vscode.Disposable[] = [
       vscode.commands.registerCommand("marquee.link", linkMarquee),
       vscode.commands.registerCommand("marquee.open", this._switchTo.bind(this)),
-      vscode.commands.registerCommand("marquee.touchbar", this._switchTo.bind(this)),
-      vscode.commands.registerCommand("marquee.expand", () => this.openGui()),
       vscode.commands.registerCommand("marquee.clear", () => this.wipe()),
       vscode.commands.registerCommand("marquee.edit", async (item: ContextMenu) => {
         if (item.type === 'Snippet') {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -112,6 +112,7 @@ export class MarqueeExtension {
     const disposables: vscode.Disposable[] = [
       vscode.commands.registerCommand("marquee.link", linkMarquee),
       vscode.commands.registerCommand("marquee.open", this._switchTo.bind(this)),
+      vscode.commands.registerCommand("marquee.touchbar", this._switchTo.bind(this)),
       vscode.commands.registerCommand("marquee.clear", () => this.wipe()),
       vscode.commands.registerCommand("marquee.edit", async (item: ContextMenu) => {
         if (item.type === 'Snippet') {

--- a/packages/extension/src/tree.view.ts
+++ b/packages/extension/src/tree.view.ts
@@ -239,9 +239,13 @@ export class Item extends vscode.TreeItem {
     }
   }
 
+  /**
+   * Define item as LinkedTodo or LinkedSnippet to enable
+   * further context operation, e.g. jump to file
+   */
   linkItem(item: any) {
     const i: any = item.item;
-    if (i.exists) {
+    if (i.origin) {
       this.contextValue = `Linked${this.contextValue}`;
     }
   }
@@ -298,8 +302,8 @@ class TodoItem extends Item implements ContextMenu {
           basePath,
           "Todo",
           {
-            command: "marquee.toggleTodo",
-            title: "Marquee toggle todo",
+            command: "marquee.todo.toggle",
+            title: "Toggle Todo",
           },
           todo.checked,
           todo.archived

--- a/packages/extension/tests/__snapshots__/extension.test.ts.snap
+++ b/packages/extension/tests/__snapshots__/extension.test.ts.snap
@@ -4,6 +4,7 @@ exports[`should be initiated with no errors 1`] = `
 Array [
   "marquee.link",
   "marquee.open",
+  "marquee.touchbar",
   "marquee.clear",
   "marquee.edit",
 ]

--- a/packages/extension/tests/__snapshots__/extension.test.ts.snap
+++ b/packages/extension/tests/__snapshots__/extension.test.ts.snap
@@ -4,8 +4,6 @@ exports[`should be initiated with no errors 1`] = `
 Array [
   "marquee.link",
   "marquee.open",
-  "marquee.touchbar",
-  "marquee.expand",
   "marquee.clear",
   "marquee.edit",
 ]

--- a/packages/extension/tests/extension.test.ts
+++ b/packages/extension/tests/extension.test.ts
@@ -29,7 +29,7 @@ jest.mock('../src/stateManager.ts', () => class {
 test('should be initiated with no errors', () => {
   const context = { subscriptions: [], extensionPath: '/foo/bar' };
   const ext = new MarqueeExtension(context as any);
-  expect(context.subscriptions).toHaveLength(4);
+  expect(context.subscriptions).toHaveLength(5);
   expect(vscode.window.createTreeView)
     .toBeCalledWith('marquee', expect.any(Object));
   expect(vscode.window.onDidChangeActiveColorTheme)

--- a/packages/extension/tests/extension.test.ts
+++ b/packages/extension/tests/extension.test.ts
@@ -29,7 +29,7 @@ jest.mock('../src/stateManager.ts', () => class {
 test('should be initiated with no errors', () => {
   const context = { subscriptions: [], extensionPath: '/foo/bar' };
   const ext = new MarqueeExtension(context as any);
-  expect(context.subscriptions).toHaveLength(6);
+  expect(context.subscriptions).toHaveLength(4);
   expect(vscode.window.createTreeView)
     .toBeCalledWith('marquee', expect.any(Object));
   expect(vscode.window.onDidChangeActiveColorTheme)

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -46,9 +46,10 @@ export interface MarqueeEvents {
   updateWidgetDisplay: Record<string, boolean>
   resetMarquee?: boolean
   telemetryEvent: {
-    eventName: string,
+    eventName: string
     properties?: Record<string, string>
-  }
+  },
+  jumpTo: string
 }
 
 export enum WorkspaceType {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -48,8 +48,7 @@ export interface MarqueeEvents {
   telemetryEvent: {
     eventName: string
     properties?: Record<string, string>
-  },
-  jumpTo: string
+  }
 }
 
 export enum WorkspaceType {

--- a/packages/widget-notes/src/extension.ts
+++ b/packages/widget-notes/src/extension.ts
@@ -11,8 +11,9 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
   constructor (context: vscode.ExtensionContext, channel: vscode.OutputChannel) {
     super(context, channel, STATE_KEY, {}, DEFAULT_STATE);
     this._disposables.push(
-      vscode.commands.registerTextEditorCommand('marquee.note.add', this._addNote.bind(this)),
+      vscode.commands.registerTextEditorCommand('marquee.note.addEditor', this._addNote.bind(this)),
       vscode.commands.registerCommand('marquee.note.move', this._moveNote.bind(this)),
+      vscode.commands.registerCommand('marquee.note.delete', this._deleteNote.bind(this)),
       vscode.commands.registerCommand("marquee.note.addEmpty", () => this.emit(
         'openDialog', { event: 'openAddNoteDialog', payload: true }
       ))
@@ -52,7 +53,7 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
    * @param item TreeView item that represents a todo in a tree view
    * @returns (un)archived todo
    */
-   private _moveNote (item: { id: string, archived: boolean }) {
+  private _moveNote (item: { id: string, archived: boolean }) {
     const awsp = this.getActiveWorkspace();
 
     if (!awsp) {
@@ -67,6 +68,16 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
 
     this.state.notes[noteIndex].workspaceId = awsp.id;
     this.updateState('notes', this.state.notes);
+    this.broadcast({ notes: this.state.notes });
+  }
+
+  /**
+   * delete note (triggered from tree view)
+   */
+  private _deleteNote (item: { id: string }) {
+    const newNotes = this.state.notes.filter((n) => n.id !== item.id);
+    this.updateState('notes', newNotes);
+    this.broadcast({ notes: this.state.notes });
   }
 }
 

--- a/packages/widget-snippets/src/extension.ts
+++ b/packages/widget-snippets/src/extension.ts
@@ -21,11 +21,11 @@ export class SnippetExtensionManager extends ExtensionManager<State, {}> {
       vscode.commands.registerCommand('marquee.snippet.move', this._moveSnippet.bind(this)),
       vscode.commands.registerCommand('marquee.snippet.addEmpty', this._addEmptySnippet.bind(this)),
       vscode.commands.registerCommand('marquee.snippet.insert', this._insertFromTreeView.bind(this)),
-      vscode.commands.registerCommand('marquee.snippet.remove', this._removeSnippet.bind(this)),
+      vscode.commands.registerCommand('marquee.snippet.delete', this._removeSnippet.bind(this)),
       vscode.commands.registerCommand('marquee.snippet.copyToClipboard', this._copyToClipboard.bind(this)),
 
       vscode.commands.registerTextEditorCommand('marquee.snippet.insertEditor', this._insertEditor.bind(this)),
-      vscode.commands.registerTextEditorCommand('marquee.snippet.add', this._addSnippet.bind(this)),
+      vscode.commands.registerTextEditorCommand('marquee.snippet.addEditor', this._addSnippet.bind(this)),
       vscode.workspace.registerTextDocumentContentProvider(ContentProvider.scheme, this._contentProvider),
       vscode.workspace.registerFileSystemProvider(SnippetStorageProvider.scheme, this._fsProvider, { isCaseSensitive: true })
     );

--- a/packages/widget-todo/src/components/PopItemContent.tsx
+++ b/packages/widget-todo/src/components/PopItemContent.tsx
@@ -63,7 +63,7 @@ const TodoPopItemContent = ({ todo, close }: TodoPopItemContentPayload) => {
         <ListItemText primary={<Typography variant="body2">Edit</Typography>} />
       </ListItem>
 
-      {todo && todo.exists && (
+      {todo && todo.origin && (
         <ListItem
           button
           onClick={() => {

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -114,7 +114,8 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
   }
 
   /**
-   * add todo
+   * Add todo highlighted in code editor, e.g. Todo: foobar
+   * see `_createDiagnostic`
    */
   private _addTodo (diagnostic: vscode.Diagnostic) {
     let body = vscode.window.activeTextEditor?.document.getText(diagnostic.range) || '';
@@ -159,6 +160,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       id: this.generateId(),
       tags: [],
       path: path,
+      origin: path,
       workspaceId: this.getActiveWorkspace()?.id || null,
     };
     const newTodos = [todo].concat(this.state.todos);
@@ -184,6 +186,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
 
     this.state.todos[todoIndex].checked = !item.checked;
     this.updateState('todos', this.state.todos);
+    this.broadcast({ todos: this.state.todos });
   }
 
   /**
@@ -200,6 +203,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
 
     this.state.todos[todoIndex].archived = !item.archived;
     this.updateState('todos', this.state.todos);
+    this.broadcast({ todos: this.state.todos });
   }
 
   /**
@@ -222,6 +226,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
 
     this.state.todos[todoIndex].workspaceId = awsp.id;
     this.updateState('todos', this.state.todos);
+    this.broadcast({ todos: this.state.todos });
   }
 }
 
@@ -246,12 +251,12 @@ class TodoInfo implements vscode.CodeActionProvider {
     diagnostic: vscode.Diagnostic
   ): vscode.CodeAction {
     const action = new vscode.CodeAction(
-      "Add todo",
+      "Marquee: Add Todo",
       vscode.CodeActionKind.QuickFix
     );
     action.command = {
       command: "marquee.todo.add",
-      title: "Add todo",
+      title: "Marquee: Add Todo",
       arguments: [diagnostic],
     };
     action.diagnostics = [diagnostic];

--- a/packages/widget-todo/src/types.ts
+++ b/packages/widget-todo/src/types.ts
@@ -7,7 +7,7 @@ export interface Todo {
   archived: boolean
   workspaceId: string | null
   tags: string[]
-  exists?: boolean
+  origin?: string
   path?: string
 }
 

--- a/packages/widget-weather/tests/extension.test.ts
+++ b/packages/widget-weather/tests/extension.test.ts
@@ -1,0 +1,8 @@
+import { activate } from '../src/extension';
+
+test('returns proper interface', () => {
+  const exp = activate({} as any, {} as any);
+  expect(Object.keys(exp.marquee)).toEqual(
+    ['disposable', 'defaultState', 'defaultConfiguration', 'setup']
+  );
+});


### PR DESCRIPTION
This patch cleans up all defined Marquee commands and makes sure:

- they are within a `Marquee` group
- they are only visible if it makes sense

This will fix situations like this where commands are added to the palette with no context and use.
![Screenshot 2022-03-03 at 15 19 42](https://user-images.githubusercontent.com/731337/156582892-888581c5-eddb-4b0e-845d-956a09018236.png)
