### PR TITLE
[💡 Feature]: Add file location for todos that were added from a file

### DIFF
--- a/packages/widget-todo/src/components/Item.tsx
+++ b/packages/widget-todo/src/components/Item.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState, useCallback } from "react";
 
 import DragHandleIcon from "@material-ui/icons/DragHandle";
 import Chip from "@material-ui/core/Chip";
+import LinkIcon from "@material-ui/icons/Link";
 import Tooltip from "@material-ui/core/Tooltip";
 import {
   Grid,
@@ -11,6 +12,7 @@ import {
   Popover,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { jumpTo } from '@vscode-marquee/utils';
 import TodoItemPop from "./ItemPop";
 import TodoPopItemContent from "./PopItemContent";
 
@@ -161,6 +163,22 @@ const TodoItem = ({ todo, isDragged, dragProps }: TodoItemProps) => {
             )}
           </Grid>
         </Grid>
+        {todo.origin && (
+          <Grid item xs>
+            <Tooltip
+              title={<Typography variant="subtitle2">{todo.path}</Typography>}
+              classes={{ tooltip: classes.customTooltip }}
+              placement="top"
+              arrow
+            >
+              <Typography variant="body2" noWrap>
+                <IconButton size="small" tabIndex={-1} onClick={() => jumpTo(todo)}>
+                  <LinkIcon />
+                </IconButton>
+              </Typography>
+            </Tooltip>
+          </Grid>
+        )}
         <Grid item xs style={{ margin: "4px" }}>
           <TodoItemPop todo={todo} />
         </Grid>

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -124,7 +124,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       return;
     }
 
-    const path = vscode.window.activeTextEditor?.document.uri.path;
+    const path = `${vscode.window.activeTextEditor?.document.uri.path}:${diagnostic.range.start.line}`;
     body = body.replace(/TODO[:]? /g, "").trim();
 
     const todo: Todo = {
@@ -133,7 +133,8 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       checked: false,
       id: this.generateId(),
       tags: [],
-      path: `${path}:${diagnostic.range.start.line}`,
+      path,
+      origin: path,
       workspaceId: this.getActiveWorkspace()?.id || null,
     };
 


### PR DESCRIPTION
### Is your feature request related to a problem?

When someone creates a todo from a file position the link between file and todo would get lost after creating it. The only way to look for the todo is to do a global search for it.

### Describe the solution you'd like.

It would be great if we could keep a link between todo and file location, for example as part of the todo list as shown in this example:

![image](https://user-images.githubusercontent.com/731337/152247031-f8692e84-08c8-4157-a00f-9ef71a574835.png)

### Describe alternatives you've considered.

_No response_

### Additional context

Submitted through Marquee feedback form.

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct