### PR TITLE
Linkable notes

### DIFF
--- a/packages/widget-notes/src/Context.tsx
+++ b/packages/widget-notes/src/Context.tsx
@@ -37,7 +37,6 @@ const NoteProvider = ({ children }: { children: React.ReactElement }) => {
       id: id,
       archived: false,
       createdAt: new Date().getTime(),
-      origin: null,
       workspaceId: isWorkspaceTodo
         ? window.activeWorkspace?.id || null
         : null,

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -1,12 +1,14 @@
 import React, { useContext, useEffect, useMemo, useCallback } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Grid, Typography, TextField, IconButton, Button } from "@material-ui/core";
-import { Clear, AddCircle } from "@material-ui/icons";
+import LinkIcon from "@material-ui/icons/Link";
+import ClearIcon from "@material-ui/icons/Clear";
+import AddCircleIcon from "@material-ui/icons/AddCircle";
 
 import SplitterLayout from "react-splitter-layout";
 import { List, AutoSizer } from "react-virtualized";
 
-import { GlobalContext, DoubleClickHelper, MarqueeWindow } from '@vscode-marquee/utils';
+import { GlobalContext, DoubleClickHelper, MarqueeWindow, jumpTo } from '@vscode-marquee/utils';
 import wrapper, { Dragger, HidePop } from "@vscode-marquee/widget";
 
 import "react-virtualized/styles.css";
@@ -57,6 +59,12 @@ let Notes = () => {
   const note = useMemo(() => {
     return notes.find((note) => note.id === noteSelected);
   }, [noteSelected, notes]);
+
+  const noteLinkFileName = useMemo(() => {
+    if (note && note.origin) {
+      return note.origin.split("/").reverse()[0].toUpperCase();
+    }
+  }, [note]);
 
   const notesArr = useMemo(() => {
     let filteredItems = notes;
@@ -127,13 +135,30 @@ let Notes = () => {
             alignItems="center"
           >
             <Grid item>
-              <Typography variant="subtitle1">Notes</Typography>
+              <Grid container direction="row" spacing={1} alignItems="center">
+                <Grid item>
+                  <Typography variant="subtitle1">Notes</Typography>
+                </Grid>
+                <Grid item>
+                  {note && noteLinkFileName && (
+                    <Button
+                      size="small"
+                      startIcon={<LinkIcon />}
+                      disableFocusRipple
+                      onClick={() => jumpTo(note)}
+                      style={{ padding: '0 5px' }}
+                    >
+                      {noteLinkFileName}
+                    </Button>
+                  )}
+                </Grid>
+              </Grid>
             </Grid>
             <Grid item>
               <Grid container direction="row" spacing={1} alignItems="center">
                 <Grid item>
                   <IconButton size="small" onClick={() => setShowAddDialog(true)}>
-                    <AddCircle fontSize="small" />
+                    <AddCircleIcon fontSize="small" />
                   </IconButton>
                 </Grid>
                 <Grid item>
@@ -191,7 +216,7 @@ let Notes = () => {
                       onChange={(e) => setNoteFilter(e.target.value)}
                       InputProps={{
                         endAdornment: (
-                          <Clear
+                          <ClearIcon
                             fontSize="small"
                             style={{ cursor: "pointer" }}
                             onClick={() => setNoteFilter("") }
@@ -238,7 +263,7 @@ let Notes = () => {
                         </Grid>
                         <Grid item>&nbsp;</Grid>
                         <Grid item>
-                          <Button startIcon={<AddCircle />} variant="outlined" onClick={() => setShowAddDialog(true)}>
+                          <Button startIcon={<AddCircleIcon />} variant="outlined" onClick={() => setShowAddDialog(true)}>
                             Create a note
                           </Button>
                         </Grid>

--- a/packages/widget-notes/src/extension.ts
+++ b/packages/widget-notes/src/extension.ts
@@ -24,7 +24,7 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
    * add note into text editor
    */
    private _addNote (editor: vscode.TextEditor) {
-    const { text, name } = this.getTextSelection(editor);
+    const { text, name, path } = this.getTextSelection(editor);
 
     if (text.length < 1) {
       return vscode.window.showWarningMessage('Marquee: no text selected');
@@ -36,6 +36,8 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
       text: text,
       id: this.generateId(),
       workspaceId: this.getActiveWorkspace()?.id || null,
+      path,
+      origin: path
     };
     const newNotes = [note].concat(this.state.notes);
     this.updateState('notes', newNotes);

--- a/packages/widget-notes/src/types.ts
+++ b/packages/widget-notes/src/types.ts
@@ -5,7 +5,9 @@ export interface Note {
   workspaceId: string | null
   title: string
   body: string
-  text: string
+  text: string,
+  path?: string,
+  origin?: string
 }
 
 export interface Events {

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -67,8 +67,6 @@ let Snippets = () => {
     if (snippet && snippet.origin) {
       return snippet.origin.split("/").reverse()[0].toUpperCase();
     }
-
-    return '';
   }, [snippet]);
 
   const snippetsArr = useMemo(() => {
@@ -139,18 +137,17 @@ let Snippets = () => {
                   <Typography variant="subtitle1">Snippets</Typography>
                 </Grid>
                 <Grid item>
-                  {snippet &&
-                    snippetLinkFileName !== "" &&
-                    snippetsArr.length !== 0 && (
-                      <Button
-                        size="small"
-                        startIcon={<LinkIcon />}
-                        disableFocusRipple
-                        onClick={() => jumpTo(snippet)}
-                      >
-                        {snippetLinkFileName}
-                      </Button>
-                    )}
+                  {snippet && snippetLinkFileName && (
+                    <Button
+                      size="small"
+                      startIcon={<LinkIcon />}
+                      disableFocusRipple
+                      style={{ padding: '0 5px' }}
+                      onClick={() => jumpTo(snippet)}
+                    >
+                      {snippetLinkFileName}
+                    </Button>
+                  )}
                 </Grid>
               </Grid>
             </Grid>


### PR DESCRIPTION
This patch adds the same behavior for notes as we have for snippets: make them linkable.
![linkableTodos](https://user-images.githubusercontent.com/731337/156779680-f8c0df7f-0310-4cb3-b6ac-bf015439f2a6.gif)

With that we have a consistent behavior between all widgets: notes, todos and snippets.
