### PR TITLE
add dependabot

### DIFF
--- a/.github/.dependabot
+++ b/.github/.dependabot
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I am not quite sure on what's the best way to make this work in a mono repo. 
I could add all packages manually to the `.dependabot.yml`, but this would need to be maintained. 
Is this something we'd want to do?

If anyone knows if there would be a better way, please let me know!

Related to #13