### PR TITLE
Add Marquee Settings button

### DIFF
--- a/packages/gui/src/dialogs/SettingsDialog.tsx
+++ b/packages/gui/src/dialogs/SettingsDialog.tsx
@@ -98,6 +98,15 @@ const SettingsDialog = React.memo(({ close }: { close: () => void }) => {
   const [value, setValue] = useState(0);
 
   const handleChange = (event: any, newValue: any) => {
+    if (event.target.innerHTML === 'Marquee Settings') {
+      return window.vscode.postMessage({
+        west: { execCommands: [{
+          command: 'workbench.action.openSettings',
+          args: ['@ext:stateful.marquee']
+        }]},
+      });
+    }
+
     setValue(newValue);
   };
   return (
@@ -121,6 +130,7 @@ const SettingsDialog = React.memo(({ close }: { close: () => void }) => {
                 >
                   <Tab label="Widgets" />
                   <Tab label="Import / Export" />
+                  <Tab label="Marquee Settings" />
                 </Tabs>
               </AppBar>
             </Grid>

--- a/packages/gui/tests/dialogs/SettingsDialog.test.tsx
+++ b/packages/gui/tests/dialogs/SettingsDialog.test.tsx
@@ -45,3 +45,22 @@ test('switches to import/export settings', () => {
 
   expect(close).toBeCalledTimes(2);
 });
+
+test('should open Marquee settings in VSCode preference view', () => {
+  window.vscode = { postMessage: jest.fn() };
+
+  const close = jest.fn();
+  const { getByText } = render(
+    <GlobalProvider>
+      <SettingsDialog close={close} />
+    </GlobalProvider>
+  );
+
+  userEvent.click(getByText('Marquee Settings'));
+  expect(window.vscode.postMessage).toBeCalledWith({
+    west: { execCommands: [{
+      command: 'workbench.action.openSettings',
+      args: ['@ext:stateful.marquee']
+    }] }
+  });
+});


### PR DESCRIPTION
To make it more obvious that all settings are now part of VSCode, let's add a button in the previous settings pane that redirects to the VSCode preference pane:
![settings](https://user-images.githubusercontent.com/731337/157406490-276bbfce-1023-46ba-b709-4beefda6a285.gif)

