### PR TITLE
Improve ability to open old snippet types

### DIFF
--- a/packages/gui/src/components/ModeTabPop.tsx
+++ b/packages/gui/src/components/ModeTabPop.tsx
@@ -15,15 +15,13 @@ const ModeTabPop = ({ name, children }: ModeTabPopProps) => {
   const [showModeTab, SetShowModeTab] = useState(false);
   const { _removeMode } = useContext(ModeContext);
 
-  const handleRightClick = useCallback(
-    (e) => {
-      //if this isn't one of the preset modes
-      if (!presetModes.includes(name)) {
-        setAnchorEl(e.currentTarget);
-      }
-    },
-    [name]
-  );
+  const handleRightClick = useCallback((e) => {
+    e.preventDefault();
+    //if this isn't one of the preset modes
+    if (!presetModes.includes(name)) {
+      setAnchorEl(e.currentTarget);
+    }
+  }, [name]);
 
   const handleClose = useCallback(() => {
     setAnchorEl(null);

--- a/packages/widget-notes/src/components/ListItem.tsx
+++ b/packages/widget-notes/src/components/ListItem.tsx
@@ -81,6 +81,7 @@ let NoteListItem = ({ note, index, keyVal, style, selected, click }: NoteListIte
   }, [note]);
 
   const handleRightClick = useCallback((e) => {
+    e.preventDefault();
     setAnchorEl(e.currentTarget);
   }, []);
 

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -107,7 +107,15 @@ let Snippets = () => {
     }
 
     if (e.detail === 2) {
-      return eventListener.emit('openSnippet', snippetsArr[index].path!);
+      let path = snippetsArr[index].path || '';
+      /**
+       * transform v2 snippets to make them editable in v3
+       */
+      if (!path.startsWith('/')) {
+        path = `/${snippetsArr[index].id}/${path}`;
+      }
+
+      return eventListener.emit('openSnippet', path);
     }
   }, [snippetsArr]);
 

--- a/packages/widget-snippets/src/components/ListItem.tsx
+++ b/packages/widget-snippets/src/components/ListItem.tsx
@@ -92,6 +92,7 @@ let SnippetListItem = ({
   }, [snippet]);
 
   const handleRightClick = useCallback((e) => {
+    e.preventDefault();
     setAnchorEl(e.currentTarget);
   }, []);
 
@@ -147,7 +148,15 @@ let SnippetListItem = ({
               <ListItem
                 button
                 onClick={(e) => {
-                  widgetEventListener.emit('openSnippet', snippet.path!);
+                  let path = snippet.path || '';
+                  /**
+                   * transform v2 snippets to make them editable in v3
+                   */
+                  if (!path.startsWith('/')) {
+                    path = `/${snippet.id}/${path}`;
+                  }
+
+                  widgetEventListener.emit('openSnippet', path!);
                   handleClose(e);
                 }}
               >

--- a/packages/widget-snippets/src/provider/SnippetStorageProvider.ts
+++ b/packages/widget-snippets/src/provider/SnippetStorageProvider.ts
@@ -30,7 +30,18 @@ export default class SnippetStorageProvider extends EventEmitter implements vsco
     }
 
     const state = this._context.globalState.get<State>(STATE_KEY);
-    const snippet = state?.snippets.find((snippet) => snippet.path === uri.path);
+    let snippet = state?.snippets.find((snippet) => snippet.path === uri.path);
+
+    /**
+     * in Marquee v2 and earlier `path` was used to recognise the source of the snippet.
+     * This has changed in v3 where `path` represents the virtual path and `origin` the
+     * source of the snippet. To allow finding old snippets (e.g. imported in v3) we do
+     * this extra check.
+     */
+    if (!snippet) {
+      const [id, path] = uri.path.split('/').filter(Boolean);
+      snippet = state?.snippets.find((snippet) => snippet.id === id && snippet.path === path);
+    }
 
     if (!snippet) {
       throw new Error(`Couldn't find snippet at ${uri.path}`);

--- a/packages/widget-snippets/tests/provider/SnippetStoreageProvider.test.ts
+++ b/packages/widget-snippets/tests/provider/SnippetStoreageProvider.test.ts
@@ -27,6 +27,14 @@ describe('SnippetStorageProvider', () => {
     }
   });
 
+  it('should be able to also find old snippet types', () => {
+    const snippets = [{ path: 'Untitled:1:0', id: '12345' }, { path: '/bar/foo' }];
+    const context = { globalState: { get: jest.fn().mockReturnValue({ snippets }) } };
+    const provider = new SnippetStorageProvider(context as any, {} as any);
+    const s = provider.stat({ path: '/12345/Untitled:1:0' } as any);
+    expect(s.id).toBe('12345');
+  });
+
   it('stat: should return file stat', () => {
     const snippets = [{ path: '/foo/bar' }, { path: '/bar/foo', id: 'foobar' }];
     const context = { globalState: { get: jest.fn().mockReturnValue({ snippets }) } };

--- a/packages/widget-todo/src/components/Item.tsx
+++ b/packages/widget-todo/src/components/Item.tsx
@@ -40,6 +40,7 @@ const TodoItem = ({ todo, isDragged, dragProps }: TodoItemProps) => {
   const id = open ? "todo-item-popover" : undefined;
 
   const handleRightClick = useCallback((e) => {
+    e.preventDefault();
     setAnchorEl(e.currentTarget);
   }, []);
 


### PR DESCRIPTION
In Marquee v2 and earlier `path` was used to recognise the source of the snippet. This has changed in v3 where `path` represents the virtual path and `origin` the source of the snippet. To allow finding old snippets (e.g. imported in v3) we do this extra check.