### PR TITLE
Remove native icon property

### DIFF
--- a/packages/extension/src/utils.ts
+++ b/packages/extension/src/utils.ts
@@ -33,8 +33,8 @@ export const DEFAULT_CONFIGURATION = {
   colorScheme: undefined
 };
 
-class GUIExtensionManager extends ExtensionManager<any, any> {
-  async updateConfiguration (prop: any, val: any) {
+class GUIExtensionManager extends ExtensionManager<typeof DEFAULT_STATE, typeof DEFAULT_CONFIGURATION> {
+  async updateConfiguration (prop: keyof typeof DEFAULT_CONFIGURATION, val: any) {
     /**
      * when updating modes the webview passes the native ascii icon (e.g. "💼") which
      * breaks when sending from webview to extension host. This ensures that we don't

--- a/packages/extension/src/utils.ts
+++ b/packages/extension/src/utils.ts
@@ -33,11 +33,30 @@ export const DEFAULT_CONFIGURATION = {
   colorScheme: undefined
 };
 
+class GUIExtensionManager extends ExtensionManager<any, any> {
+  async updateConfiguration (prop: any, val: any) {
+    /**
+     * when updating modes the webview passes the native ascii icon (e.g. "💼") which
+     * breaks when sending from webview to extension host. This ensures that we don't
+     * includes these broken ascii characters into the VSCode settings file
+     */
+    if (prop === 'modes') {
+      for (const modeName of Object.keys(val)) {
+        if (val[modeName].icon) {
+          delete val[modeName].icon.native;
+        }
+      }
+    }
+
+    super.updateConfiguration(prop, val);
+  }
+}
+
 export function activateGUI (
   context: vscode.ExtensionContext,
   channel: vscode.OutputChannel
 ) {
-  const stateManager = new ExtensionManager<{}, {}>(context, channel, 'configuration', DEFAULT_CONFIGURATION, DEFAULT_STATE);
+  const stateManager = new GUIExtensionManager(context, channel, 'configuration', DEFAULT_CONFIGURATION, DEFAULT_STATE);
 
   return {
     marquee: {

--- a/packages/extension/tests/utils.test.ts
+++ b/packages/extension/tests/utils.test.ts
@@ -1,6 +1,22 @@
 import vscode from 'vscode';
 import { isExpanded, filterByScope, activateGUI, linkMarquee } from '../src/utils';
 
+jest.mock('@vscode-marquee/utils/extension', () => class {
+  static defaultConfigurations = {
+    'marquee.configuration.modes': { default: 'marquee.configuration.modes' },
+    'marquee.configuration.proxy': { default: 'marquee.configuration.proxy' },
+    'marquee.configuration.fontSize': { default: 'marquee.configuration.fontSize' },
+    'marquee.configuration.launchOnStartup': { default: 'marquee.configuration.launchOnStartup' },
+    'marquee.configuration.workspaceLaunch': { default: 'marquee.configuration.workspaceLaunch' }
+  };
+  setBroadcaster = jest.fn();
+  state = 'foobar';
+  configuration = {} as any;
+  updateConfiguration (prop: string, val: any) {
+    this.configuration[prop] = val;
+  }
+});
+
 test('isExpanded', () => {
   expect(isExpanded(1)).toBe('foo');
   expect(isExpanded(4)).toBe('bar');
@@ -23,9 +39,26 @@ test('activateGUI', () => {
     }
   };
   const extExport = activateGUI(context as any, {} as any);
-  expect(extExport.marquee.disposable.state).toEqual({
-    modeName: 'default',
-    prevMode: null,
+  expect(extExport.marquee.disposable.state).toEqual('foobar');
+});
+
+test('extension manager removes native icon', () => {
+  const context = {
+    globalState: {
+      get: jest.fn().mockReturnValue({}),
+      setKeysForSync: jest.fn()
+    }
+  };
+  const extExport = activateGUI(context as any, {} as any);
+  extExport.marquee.disposable.updateConfiguration('modes', {
+    foobar: {
+      icon: { foo: 'bar', native: 123 }
+    }
+  });
+  expect(extExport.marquee.disposable.configuration).toEqual({
+    modes: {
+      foobar: { icon: { foo: 'bar' } }
+    }
   });
 });
 


### PR DESCRIPTION
When updating our Marquee mode we transfer the native icon property, e.g. 💼 ). Unfortunately transferring it from the webview causes some weird ascii transformation that Marquee stores in the VSCode settings:

![image (1)](https://user-images.githubusercontent.com/731337/157444771-9f22a3da-05cb-466d-bfb5-21eb66cf5e28.png)

This patch ensures that the `native` property is removed before storing it.
