### PR TITLE
Only make VSCode updates if state or configuration as changed

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,9 +7,11 @@
   "types": "./build/index.d.ts",
   "dependencies": {
     "@types/lodash.pick": "^4.4.6",
+    "@types/object-hash": "^2.2.1",
     "@types/uuid": "^8.3.4",
     "hex-rgb": "4.3.0",
     "lodash.pick": "^4.4.0",
+    "object-hash": "^3.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {},

--- a/packages/utils/tests/extension.test.ts
+++ b/packages/utils/tests/extension.test.ts
@@ -107,6 +107,27 @@ test('updateConfiguration', async () => {
   expect(config.update).toBeCalledWith('widget.todo.defaultConfig', 'some other new value', 1);
 });
 
+test('updateConfiguration does not do anything if values are equal', async () => {
+  const manager = new ExtensionManager(
+    context as any,
+    { appendLine: jest.fn() } as any,
+    'widget.todo',
+    { prop: { a: 'b' , c: 'd' } },
+    {}
+  );
+  const waitPromise = new Promise((resolve) => setTimeout(resolve, 100));
+  const config = {
+    update: jest.fn().mockReturnValue(waitPromise),
+    get: jest.fn().mockReturnValue('some new value')
+  };
+
+  ;(vscode.workspace.getConfiguration as jest.Mock)
+    .mockClear()
+    .mockReturnValue(config);
+  await manager.updateConfiguration('prop', { c: 'd', a: 'b' });
+  expect(config.update).toBeCalledTimes(0);
+});
+
 test('updateState', async () => {
   const manager = new ExtensionManager(
     context as any,
@@ -122,6 +143,19 @@ test('updateState', async () => {
     defaultState: 'some new state',
     defaultConfig: 'old config'
   });
+});
+
+test('updateState does not do anything if values are equal', async () => {
+  const manager = new ExtensionManager(
+    context as any,
+    { appendLine: jest.fn() } as any,
+    'widget.todo',
+    {},
+    { prop: { a: 'b' , c: 'd' } }
+  );
+  manager.emit = jest.fn();
+  await manager.updateState('prop', { c: 'd', a: 'b' });
+  expect(manager.emit).toBeCalledTimes(0);
 });
 
 test('clear', async () => {

--- a/packages/widget-github/src/Context.tsx
+++ b/packages/widget-github/src/Context.tsx
@@ -28,15 +28,24 @@ const TrendProvider = ({ children }: Props) => {
   };
 
   const _updateSince = (since?: Since) => {
-    providerValues.setSince(since?.name as SinceConfiguration || '');
+    if (!since?.name) {
+      return;
+    }
+    providerValues.setSince(since.name as SinceConfiguration);
   };
 
   const _updateLanguage = (language?: SpokenLanguage) => {
-    providerValues.setLanguage(language?.name || '');
+    if (!language?.name) {
+      return;
+    }
+    providerValues.setLanguage(language.name);
   };
 
   const _updateSpoken = (spoken?: SpokenLanguage) => {
-    providerValues.setSpoken(spoken?.name || '');
+    if (!spoken?.name) {
+      return;
+    }
+    providerValues.setSpoken(spoken.name);
   };
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1863,6 +1863,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.17.tgz#a8ddf6e0c2341718d74ee3dc413a13a042c45a0c"
   integrity sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw==
 
+"@types/object-hash@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-2.2.1.tgz#67c169f8f033e0b62abbf81df2d00f4598d540b9"
+  integrity sha512-i/rtaJFCsPljrZvP/akBqEwUP2y5cZLOmvO+JaYnz01aPknrQ+hB5MRcO7iqCUsFaYfTG8kGfKUyboA07xeDHQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -6254,6 +6259,11 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
+  integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"


### PR DESCRIPTION
So far we have been interacting with the VSCode state and configuration interface even though there were no changes to certain properties. This has caused a variety of side effects. Let's be more diligent about this and only change the configuration if we actually have a new property.