### PR TITLE
Improvements on config synchronisation

### DIFF
--- a/packages/extension/src/constants.ts
+++ b/packages/extension/src/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_FONT_SIZE = 5;
 
 export const RETRY = 4 * 1000;
 export const INIT = 50;
+export const MODES_UPDATE_TIMEOUT = 2 * 1000;
 export const config = vscode.workspace.getConfiguration('marquee');
 export const FILE_FILTER = { 'Marquee Settings': ['json'] };
 export const CONFIG_FILE_TYPE = 'MarqueeSettings';

--- a/packages/extension/src/gui.view.ts
+++ b/packages/extension/src/gui.view.ts
@@ -220,7 +220,6 @@ export class MarqueeGui extends EventEmitter {
     this.panel.webview.html = content;
     this.panel.webview.onDidReceiveMessage(this._handleWebviewMessage.bind(this));
     this.panel.onDidDispose(this._disposePanel.bind(this));
-    this.panel.onDidChangeViewState(this._handleViewStateChange.bind(this));
   }
 
   private _disposePanel () {
@@ -244,7 +243,6 @@ export class MarqueeGui extends EventEmitter {
     if (e.ready) {
       telemetry.sendTelemetryEvent('guiOpen');
       this.guiActive = true;
-      this._handleViewStateChange({ webviewPanel: { visible: true } } as any);
       return this.emit('webview.open');
     }
   }
@@ -272,16 +270,6 @@ export class MarqueeGui extends EventEmitter {
       break;
       default:
         vscode.window.showInformationMessage(message);
-    }
-  }
-
-  private _handleViewStateChange (e: vscode.WebviewPanelOnDidChangeViewStateEvent) {
-    telemetry.sendTelemetryEvent('viewStateChange', { visible: `${e.webviewPanel.visible}` });
-    const widgetDisposables = this.stateMgr.widgetExtensions
-      .map((w) => w.exports?.marquee?.disposable)
-      .filter(Boolean);
-    for (const widgetExtension of widgetDisposables) {
-      widgetExtension.stopListenOnChangeEvents = e.webviewPanel.visible;
     }
   }
 }

--- a/packages/extension/tests/gui.view.test.ts
+++ b/packages/extension/tests/gui.view.test.ts
@@ -7,15 +7,13 @@ const stateMgr = {
   widgetExtensions: [
     {
       exports: { marquee: { disposable: {
-        on: jest.fn(),
-        stopListenOnChangeEvents: false
+        on: jest.fn()
       } } },
       packageJSON: {}
     },
     {
       exports: { marquee: { disposable: {
-        on: jest.fn(),
-        stopListenOnChangeEvents: false
+        on: jest.fn()
       } } },
       packageJSON: {}
     }
@@ -129,7 +127,6 @@ test('_handleWebviewMessage', () => {
   const gui = new MarqueeGui('context' as any, stateMgr as any);
   gui['_executeCommand'] = jest.fn();
   gui['_handleNotifications'] = jest.fn();
-  gui['_handleViewStateChange'] = jest.fn();
   gui['emit'] = jest.fn();
 
   gui['_handleWebviewMessage']({ west: { execCommands: ['foo', 'bar'] } });
@@ -143,15 +140,5 @@ test('_handleWebviewMessage', () => {
   expect(gui['guiActive']).toBe(false);
   gui['_handleWebviewMessage']({ ready: true });
   expect(gui['guiActive']).toBe(true);
-  expect(gui['_handleViewStateChange']).toBeCalledWith({ webviewPanel: { visible: true } });
   expect(gui.emit).toBeCalledWith('webview.open');
-});
-
-test('_handleViewStateChange', () => {
-  const gui = new MarqueeGui('context' as any, stateMgr as any);
-  expect(stateMgr.widgetExtensions[0].exports.marquee.disposable.stopListenOnChangeEvents).toBe(false);
-  expect(stateMgr.widgetExtensions[1].exports.marquee.disposable.stopListenOnChangeEvents).toBe(false);
-  gui['_handleViewStateChange']({ webviewPanel: { visible: true }} as any);
-  expect(stateMgr.widgetExtensions[0].exports.marquee.disposable.stopListenOnChangeEvents).toBe(true);
-  expect(stateMgr.widgetExtensions[1].exports.marquee.disposable.stopListenOnChangeEvents).toBe(true);
 });

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -23,7 +23,6 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
     vscode.workspace.onDidChangeConfiguration(this._onConfigChange.bind(this))
   ];
   protected _subscriptions: { unsubscribe: Function }[] = [];
-  private _stopListenOnChangeEvents = false;
 
   constructor (
     protected _context: vscode.ExtensionContext,
@@ -62,20 +61,7 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
     return this._configuration;
   }
 
-  set stopListenOnChangeEvents (val: boolean) {
-    this._stopListenOnChangeEvents = val;
-  }
-
   private _onConfigChange (event: vscode.ConfigurationChangeEvent) {
-    /**
-     * if the change was triggered by the user through the UI we don't
-     * need to act on it because the config change will be already
-     * executed
-     */
-    if (this._stopListenOnChangeEvents) {
-      return false;
-    }
-
     for (const configKey of Object.keys(this.configuration)) {
       const prop = configKey as keyof Configuration;
 

--- a/packages/utils/tests/extension.test.ts
+++ b/packages/utils/tests/extension.test.ts
@@ -44,7 +44,7 @@ test('_onConfigChange', () => {
     context as any,
     { appendLine: jest.fn() } as any,
     'widget.todo',
-    { defaultConfig: true },
+    { defaultConfig: true, modes: { foo: 'bar' } },
     { defaultState: true }
   );
   manager['broadcast'] = jest.fn();
@@ -52,12 +52,12 @@ test('_onConfigChange', () => {
     .mockClear()
     .mockReturnValue({ get: jest.fn().mockReturnValue('some new value') });
 
-  manager['_stopListenOnChangeEvents'] = true;
   const event = { affectsConfiguration: jest.fn() };
-  expect(manager['_onConfigChange'](event)).toBe(false);
-  expect(event.affectsConfiguration).toBeCalledTimes(0);
+  expect(manager['_onConfigChange'](event)).toBe(true);
+  // assert that it only checks for defaultConfig prop but skips "modes"
+  expect(event.affectsConfiguration).toBeCalledTimes(1);
+  event.affectsConfiguration.mockClear();
 
-  manager['_stopListenOnChangeEvents'] = false;
   event.affectsConfiguration.mockReturnValue(false);
   expect(manager['_onConfigChange'](event)).toBe(true);
   expect(vscode.workspace.getConfiguration).toHaveBeenCalledTimes(0);
@@ -65,7 +65,7 @@ test('_onConfigChange', () => {
   event.affectsConfiguration.mockReturnValue(true);
   expect(manager['_onConfigChange'](event)).toBe(true);
   expect(vscode.workspace.getConfiguration).toHaveBeenCalledTimes(1);
-  expect(manager.configuration).toEqual({ defaultConfig: 'some new value' });
+  expect(manager['broadcast']).toHaveBeenCalledTimes(1);
   expect(manager['broadcast']).toHaveBeenCalledWith({ defaultConfig: 'some new value' });
 });
 


### PR DESCRIPTION
If developers have multiple VSCode windows open, we want to make sure that all changes are applied to all windows. Our current sync mechanism wasn't optimal as it didn't recognised for the scenario that both windows have Marquee webview open. This patch improves this behavior.