### PR TITLE
Allow widgets to reset state

### DIFF
--- a/packages/gui/src/components/ModeTabPop.tsx
+++ b/packages/gui/src/components/ModeTabPop.tsx
@@ -12,7 +12,7 @@ interface ModeTabPopProps {
 
 const ModeTabPop = ({ name, children }: ModeTabPopProps) => {
   const [anchorEl, setAnchorEl] = useState(null);
-  const [showModeTab, SetShowModeTab] = useState(false);
+  const [showModeTab, setShowModeTab] = useState(false);
   const { _removeMode } = useContext(ModeContext);
 
   const handleRightClick = useCallback((e) => {
@@ -40,7 +40,7 @@ const ModeTabPop = ({ name, children }: ModeTabPopProps) => {
   return (
     <>
       {showModeTab && (
-        <ModeEditDialog name={name} />
+        <ModeEditDialog onClose={() => setShowModeTab(false)} name={name} />
       )}
       <div style={{ width: "100%" }} onContextMenu={handleRightClick}>
         {children}
@@ -62,7 +62,7 @@ const ModeTabPop = ({ name, children }: ModeTabPopProps) => {
         <ListItem
           button
           onClick={() => {
-            SetShowModeTab(true);
+            setShowModeTab(true);
             handleClose();
           }}
         >

--- a/packages/gui/src/contexts/ModeContext.tsx
+++ b/packages/gui/src/contexts/ModeContext.tsx
@@ -84,9 +84,7 @@ const ModeProvider = ({ children }: Props) => {
   };
 
   const _resetModes = () => {
-    providerValues.setModes(undefined as any);
-    providerValues.setModeName('default');
-    providerValues.setPrevMode(null);
+    modeState.emit<any>('clear', null);
   };
 
   const _removeMode = (removeModeName: string) => {

--- a/packages/gui/src/contexts/ModeContext.tsx
+++ b/packages/gui/src/contexts/ModeContext.tsx
@@ -84,7 +84,7 @@ const ModeProvider = ({ children }: Props) => {
   };
 
   const _resetModes = () => {
-    modeState.emit<any>('clear', null);
+    modeState.emit<any>('clear', undefined);
   };
 
   const _removeMode = (removeModeName: string) => {

--- a/packages/gui/src/dialogs/ModeEditDialog.tsx
+++ b/packages/gui/src/dialogs/ModeEditDialog.tsx
@@ -12,11 +12,11 @@ import ModeContext from "../contexts/ModeContext";
 import EmojiPop from "../components/EmojiPop";
 
 interface ModeEditDialogProps {
-  _close?: (event?: MouseEvent<HTMLButtonElement>) => void
+  onClose: (event?: MouseEvent<HTMLButtonElement>) => void
   name: string
 }
 
-const ModeEditDialog = React.memo(({ _close, name }: ModeEditDialogProps) => {
+const ModeEditDialog = React.memo(({ onClose, name }: ModeEditDialogProps) => {
   const { modes, _duplicateMode } = useContext(ModeContext);
   const [modeName, setModeName] = useState(name);
   const [emoji, setEmoji] = useState(modes[name].icon);
@@ -29,25 +29,21 @@ const ModeEditDialog = React.memo(({ _close, name }: ModeEditDialogProps) => {
   const updateMode = useCallback(() => {
     if (!error) {
       _duplicateMode(name, modeName, emoji!);
-      if (_close) {
-        _close();
-      }
+      onClose();
     } else {
       modeNameInputRef!.focus();
     }
   }, [name, modeName, emoji]);
 
   return (
-    <DialogContainer fullWidth={true} onClose={_close}>
-      <DialogTitle onClose={_close}>Duplicate Mode</DialogTitle>
+    <DialogContainer fullWidth={true} onClose={onClose}>
+      <DialogTitle onClose={onClose}>Duplicate Mode</DialogTitle>
       <DialogContent dividers={true}>
         <TextField
           inputProps={{ ref: (input: HTMLButtonElement) => (modeNameInputRef = input) }}
           error={error}
           fullWidth
-          onChange={(e) => {
-            setModeName(e.target.value);
-          }}
+          onChange={(e) => setModeName(e.target.value)}
           name="modeName"
           autoFocus
           value={modeName}
@@ -71,9 +67,14 @@ const ModeEditDialog = React.memo(({ _close, name }: ModeEditDialogProps) => {
       </DialogContent>
       <DialogActions>
         <Button
-          onClick={() => {
-            updateMode();
-          }}
+          onClick={() => onClose()}
+          variant="contained"
+          color="secondary"
+        >
+          Close
+        </Button>
+        <Button
+          onClick={() => updateMode()}
           variant="contained"
           color="primary"
         >

--- a/packages/gui/tests/contexts/ModeContext.test.tsx
+++ b/packages/gui/tests/contexts/ModeContext.test.tsx
@@ -59,6 +59,7 @@ test('WidgetLayout filters non display widgets', () => {
   act(() => { __removeMode('foobar'); });
   expect(providerValues.setModes).toBeCalledTimes(1);
 
+  listener.emit = jest.fn();
   act(() => { __resetModes(); });
-  expect(providerValues.setModeName).toBeCalledWith('default');
+  expect(listener.emit).toBeCalledWith('clear', undefined);
 });

--- a/packages/gui/tests/dialogs/ModeEditDialog.test.tsx
+++ b/packages/gui/tests/dialogs/ModeEditDialog.test.tsx
@@ -11,7 +11,7 @@ jest.mock('../../src/contexts/ModeContext');
 test('should render component', () => {
   const close = jest.fn();
   const { getByText } = render(<ModeProvider>
-    <ModeEditDialog _close={close} name="default" />
+    <ModeEditDialog onClose={close} name="default" />
   </ModeProvider>);
   userEvent.click(getByText('Add'));
   expect(_duplicateMode).toBeCalledWith('default', 'default', undefined);

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -215,6 +215,7 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
 
   public setBroadcaster (tangle: Client<State & Configuration>) {
     this._tangle = tangle;
+    this._tangle.on<any>('clear', this.clear.bind(this));
 
     /**
      * listen on configuration changes

--- a/packages/utils/tests/extension.test.ts
+++ b/packages/utils/tests/extension.test.ts
@@ -268,7 +268,8 @@ test('getTextSelection', () => {
 
 test('setBroadcaster', () => {
   const tangle = {
-    listen: jest.fn().mockReturnValue('a subscription')
+    listen: jest.fn().mockReturnValue('a subscription'),
+    on: jest.fn()
   };
   const manager = new ExtensionManager(
     context as any,
@@ -278,6 +279,7 @@ test('setBroadcaster', () => {
     { defaultState: true }
   );
   manager.setBroadcaster(tangle as any);
+  expect(tangle.on).toBeCalledWith('clear', expect.any(Function));
   expect(tangle.listen).toBeCalledWith('defaultState', expect.any(Function));
   expect(tangle.listen).toBeCalledWith('defaultConfig', expect.any(Function));
   expect(manager['_subscriptions']).toEqual(['a subscription', 'a subscription']);


### PR DESCRIPTION
Resetting modes caused a runtime error because setting `modes` to `undefined` would break. This PR patches this by allowing every widget to reset its state from the frontend.