### PR TITLE
Showcase how to use tangle's whenReady to push data when widgets are ready to receive them

### DIFF
--- a/docs/CustomWidgets.md
+++ b/docs/CustomWidgets.md
@@ -35,6 +35,8 @@ To add your widget to Marquee add the following to your extension:
 
 If your extension manages state data or other information you want to display, you can send them to your widget using [`tangle`](https://www.npmjs.com/package/tangle). Tangle is the data communication layer and allows to share state as well as events from your original extension and the Marquee webview. In order to iniate a communication channel return an object within your [activate method](https://code.visualstudio.com/api/get-started/extension-anatomy#extension-entry-file) or your extension entry file, e.g.:
 
+> Please note that the `whenReady` hook below is optional and resolves once Marquee (counter-party JS sandbox) is ready to receive state updates. It's only required if sequence of events is important. For more information check out the [tangle docs](https://www.npmjs.com/package/tangle)' paragraph about lifecycle hooks.
+
 ```ts
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
@@ -64,12 +66,14 @@ export function activate(context: vscode.ExtensionContext) {
   return {
     marquee: {
       setup: (tangle: Client<{ counter: number }>) => {
-        let i = 0;
-        setInterval(() => {
-          tangle.emit('counter', ++i);
-        }, 1000);
-      }
-    }
+        return tangle.whenReady().then(() => {
+          let i = 0
+          setInterval(() => {
+            tangle.emit('counter', ++i)
+          }, 1000)
+        })
+      },
+    },
   }
 }
 ```

--- a/docs/CustomWidgets.md
+++ b/docs/CustomWidgets.md
@@ -33,7 +33,7 @@ To add your widget to Marquee add the following to your extension:
 
 ## Data Communication
 
-If your extension manages state data or other information you want to display, you can send them to your widget using [`tangle`](https://www.npmjs.com/package/tangle). Tangle is the data communication layer and allows to share state as well as events from your original extension and the Marquee webview. In order to iniate a communication channel return an object within your [activate method](https://code.visualstudio.com/api/get-started/extension-anatomy#extension-entry-file) or your extension entry file, e.g.:
+If your extension manages state data or other information you want to display, you can send them to your widget using [`tangle`](https://www.npmjs.com/package/tangle). Tangle is the data communication layer and allows to share state as well as events from your original extension and the Marquee webview. In order to iniate a communication channel return an object within your [activate method](https://code.visualstudio.com/api/get-started/extension-anatomy#extension-entry-file) or your extension entry file, please see below.
 
 > Please note that the `whenReady` hook below is optional and resolves once Marquee (counter-party JS sandbox) is ready to receive state updates. It's only required if sequence of events is important. For more information check out the [tangle docs](https://www.npmjs.com/package/tangle)' paragraph about lifecycle hooks.
 

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -19,7 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
      */
     marquee: {
       setup: (tangle: Client<{ counter: number }>) => {
-        tangle.readyPromise().then(() => {
+        tangle.whenReady().then(() => {
           let i = 0;
           setInterval(() => {
             tangle.emit("counter", ++i);

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -1,16 +1,16 @@
-import type vscode from "vscode";
-import type { Client } from "tangle";
+import type vscode from 'vscode'
+import type { Client } from 'tangle'
 
-import telemetry from "./telemetry";
-import { MarqueeExtension } from "./extension";
-import { getExtProps } from "@vscode-marquee/utils/extension";
+import telemetry from './telemetry'
+import { MarqueeExtension } from './extension'
+import { getExtProps } from '@vscode-marquee/utils/extension'
 
-export function activate(context: vscode.ExtensionContext) {
-  telemetry.sendTelemetryEvent("extensionActivate", getExtProps());
-  new MarqueeExtension(context);
+export function activate (context: vscode.ExtensionContext) {
+  telemetry.sendTelemetryEvent('extensionActivate', getExtProps())
+  new MarqueeExtension(context)
 
-  if (process.env.NODE_ENV !== "development") {
-    return {};
+  if (process.env.NODE_ENV !== 'development') {
+    return {}
   }
 
   return {
@@ -20,17 +20,17 @@ export function activate(context: vscode.ExtensionContext) {
     marquee: {
       setup: (tangle: Client<{ counter: number }>) => {
         tangle.whenReady().then(() => {
-          let i = 0;
+          let i = 0
           setInterval(() => {
-            tangle.emit("counter", ++i);
-          }, 1000);
-        });
+            tangle.emit('counter', ++i)
+          }, 1000)
+        })
       },
     },
-  };
+  }
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {
-  telemetry.sendTelemetryEvent("extensionDeactivate");
+export function deactivate () {
+  telemetry.sendTelemetryEvent('extensionDeactivate')
 }

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -19,7 +19,7 @@ export function activate (context: vscode.ExtensionContext) {
      */
     marquee: {
       setup: (tangle: Client<{ counter: number }>) => {
-        tangle.whenReady().then(() => {
+        return tangle.whenReady().then(() => {
           let i = 0
           setInterval(() => {
             tangle.emit('counter', ++i)

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -1,16 +1,16 @@
-import type vscode from 'vscode'
-import type { Client } from 'tangle'
+import type vscode from "vscode";
+import type { Client } from "tangle";
 
-import telemetry from './telemetry'
-import { MarqueeExtension } from './extension'
-import { getExtProps } from '@vscode-marquee/utils/extension'
+import telemetry from "./telemetry";
+import { MarqueeExtension } from "./extension";
+import { getExtProps } from "@vscode-marquee/utils/extension";
 
-export function activate (context: vscode.ExtensionContext) {
-  telemetry.sendTelemetryEvent('extensionActivate', getExtProps())
-  new MarqueeExtension(context)
+export function activate(context: vscode.ExtensionContext) {
+  telemetry.sendTelemetryEvent("extensionActivate", getExtProps());
+  new MarqueeExtension(context);
 
-  if (process.env.NODE_ENV !== 'development') {
-    return {}
+  if (process.env.NODE_ENV !== "development") {
+    return {};
   }
 
   return {
@@ -19,16 +19,18 @@ export function activate (context: vscode.ExtensionContext) {
      */
     marquee: {
       setup: (tangle: Client<{ counter: number }>) => {
-        let i = 0
-        setInterval(() => {
-          tangle.emit('counter', ++i)
-        }, 1000)
-      }
-    }
-  }
+        tangle.readyPromise().then(() => {
+          let i = 0;
+          setInterval(() => {
+            tangle.emit("counter", ++i);
+          }, 1000);
+        });
+      },
+    },
+  };
 }
 
 // this method is called when your extension is deactivated
-export function deactivate () {
-  telemetry.sendTelemetryEvent('extensionDeactivate')
+export function deactivate() {
+  telemetry.sendTelemetryEvent("extensionDeactivate");
 }

--- a/packages/extension/tests/index.test.ts
+++ b/packages/extension/tests/index.test.ts
@@ -14,7 +14,9 @@ jest.mock('@vscode-marquee/utils/extension', () => ({
 
 jest.useFakeTimers()
 
-test('should activate extension manager', () => {
+test('should activate extension manager', async () => {
+  jest.clearAllTimers()
+
   let exp = activate('context' as any)
   expect(sendTelemetryEvent).toBeCalledWith('extensionActivate', expect.any(Object))
 
@@ -22,8 +24,8 @@ test('should activate extension manager', () => {
 
   process.env.NODE_ENV = 'development'
   exp = activate('context' as any)
-  const client = { emit: jest.fn() }
-  exp.marquee!.setup(client as any)
+  const client = { whenReady: jest.fn().mockResolvedValue({}), emit: jest.fn() }
+  await exp.marquee!.setup(client as any)
 
   jest.advanceTimersByTime(2000)
   expect(client.emit).toBeCalledWith('counter', 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9612,9 +9612,9 @@ symbol-tree@^3.2.4:
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 tangle@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/tangle/-/tangle-1.0.5.tgz#4b263a9b733291c109ca5387f764efc09127ac79"
-  integrity sha512-b5ysAh4K2ualsYy+DUs+sY7XXpDIWtG63PWh/WXxszqMV492u5J0pl3XSlFAqCnsuuGIKwIN2H6ar08dsqf3ig==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tangle/-/tangle-1.1.0.tgz#7d492710b2c24b0596c44dc1f46fe788cf75b308"
+  integrity sha512-HQsd6suCEaVX9J/bOMAkkWu67p7rfj827lY+9FX9zCMPuVYk5EdQ4AdsAJhddPqZZJYWqcSSqHQQQyzTziMpYw==
   dependencies:
     rxjs "^7.4.0"
     web-worker "^1.2.0"


### PR DESCRIPTION
The `whenReady` hook is particularly important when sequence order or completeness of application state updates matter.