### PR TITLE
Fix utf8 <> ascii encoding issue

### DIFF
--- a/packages/extension/src/extension.html
+++ b/packages/extension/src/extension.html
@@ -39,12 +39,18 @@
       }
     </style>
     <script nonce="<%= it.nonce %>">
+      function b64DecodeUnicode(str) {
+        // Going backwards: from bytestream, to percent-encoding, to original string.
+        return decodeURIComponent(atob(str).split('').map(function(c) {
+            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+        }).join(''));
+      }
       window.activeWorkspace = <%~ JSON.stringify(it.aws) %>;
       window.marqueeUserProps = '<%~ JSON.stringify(it.props) %>';
       window.marqueeBackendBaseUrl = '<%= it.baseUrl %>';
       window.marqueeBackendGeoUrl = '<%= it.geoUrl %>';
       window.marqueeBackendFwdGeoUrl = '<%= it.fwdGeoUrl %>';
-      window.marqueeStateConfiguration = JSON.parse(atob('<%= it.widgetStateConfigurations %>'));
+      window.marqueeStateConfiguration = JSON.parse(b64DecodeUnicode('<%= it.widgetStateConfigurations %>'));
       window.marqueeThirdPartyWidgets = <%= it.widgetScripts.length %>;
     </script>
 </head>


### PR DESCRIPTION
Fixed the utf8 parsing issue. However, when I reenabled the test to include an emoji (multi-byte unicode char) I ran into the issue that likely led to test being skipped in the first place. Logs are here https://github.com/stateful/vscode-marquee/runs/6600538448?check_suite_focus=true

Going ahead with the merge since fixing this parsing issue seems higher priority. Adding @christian-bromann for retro-review.