### PR TITLE
Fix bug where errors persist

### DIFF
--- a/packages/widget-welcome/src/extension.ts
+++ b/packages/widget-welcome/src/extension.ts
@@ -141,10 +141,16 @@ export function activate (
 ) {
   stateManager = new StateManager(context, channel)
 
+  // don't allow errors to be recovered from default state
+  const defaultState = stateManager.state
+  if (defaultState.error) {
+    defaultState.error = null
+  }
+
   return {
     marquee: {
       disposable: stateManager,
-      defaultState: stateManager.state,
+      defaultState,
       defaultConfiguration: stateManager.configuration,
       setup: stateManager.setBroadcaster.bind(stateManager)
     }

--- a/packages/widget-welcome/src/extension.ts
+++ b/packages/widget-welcome/src/extension.ts
@@ -103,7 +103,9 @@ class StateManager extends ExtensionManager<State & Events, Configuration> {
     /**
      * only broadcast if we haven't before or a new trick was received
      */
-    if (!this._prevtricks || this._prevtricks.length < result.length) {
+    const prevTrickIds = new Set(this._prevtricks?.map((trick) => trick.id) ?? [])
+    const netNewTrickIds = new Set(result.filter(resTrick => !prevTrickIds.has(resTrick.id)))
+    if (!this._prevtricks || netNewTrickIds.size > 0) {
       this._prevtricks = result
       this._channel.appendLine(`Broadcast ${result.length} tricks`)
       this.broadcast({ error: null, tricks: result })


### PR DESCRIPTION
This bug is tricky. Under the circumstances where the last successfully retrieved tricks array has the same length as the new it won't broadcast tricks across the channel. This is particularly bad if an error has happened in the meantime and once recovered the recovery won't be broadcasted either due to the error lingering in persistence.

My bugfix will filter out errors as loading time to account for the fact there's likely already persisted state that includes errors.