### PR TITLE
[🐛 Bug]: Widget border colors

### DIFF
--- a/packages/gui/src/components/ModeConfigToolbar.tsx
+++ b/packages/gui/src/components/ModeConfigToolbar.tsx
@@ -24,7 +24,7 @@ const Root = styled('div')((
   },
 
   [`& .${classes.toolbar}`]: {
-    borderBottom: '1px solid var(--vscode-foreground)',
+    borderBottom: '1px solid var(--vscode-editorGroup-border)',
   },
 
   [`& .${classes.vert}`]: {

--- a/packages/widget-github/src/Widget.tsx
+++ b/packages/widget-github/src/Widget.tsx
@@ -49,7 +49,7 @@ let Github = () => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid
@@ -144,7 +144,7 @@ let Github = () => {
                       marginTop: '4px',
                       marginBottom: '4px',
                       padding: '16px',
-                      borderBottom: '1px solid var(--vscode-foreground)',
+                      borderBottom: '1px solid var(--vscode-editorGroup-border)',
                     }}
                   >
                     <Grid

--- a/packages/widget-markdown/src/Widget.tsx
+++ b/packages/widget-markdown/src/Widget.tsx
@@ -39,7 +39,7 @@ const Markdown = () => {
       <Grid item style={{ maxWidth: '100%' }}>
         <Box
           sx={{
-            borderBottom: '1px solid var(--vscode-foreground)',
+            borderBottom: '1px solid var(--vscode-editorGroup-border)',
             padding: '8px',
           }}
         >

--- a/packages/widget-news/src/Widget.tsx
+++ b/packages/widget-news/src/Widget.tsx
@@ -34,7 +34,7 @@ let News = () => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -114,7 +114,7 @@ let Notes = () => {
     <>
       <Grid item style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid

--- a/packages/widget-notes/src/dialogs/AddDialog.tsx
+++ b/packages/widget-notes/src/dialogs/AddDialog.tsx
@@ -54,7 +54,7 @@ const AddDialog = React.memo(({ close }: { close: () => void }) => {
         <div style={{ height: '8px', minWidth: '100%' }} />
 
         <NoteEditor
-          border="1px solid var(--vscode-foreground)"
+          border="1px solid var(--vscode-editorGroup-border)"
           name="add"
           _change={(newBody, newText) => {
             setBody(newBody)

--- a/packages/widget-notes/src/dialogs/EditDialog.tsx
+++ b/packages/widget-notes/src/dialogs/EditDialog.tsx
@@ -60,7 +60,7 @@ const EditDialog = React.memo(({ close, note }: NoteEditDialogProps) => {
         <div style={{ height: '8px', minWidth: '100%' }} />
 
         <NoteEditor
-          border="1px solid var(--vscode-foreground)"
+          border="1px solid var(--vscode-editorGroup-border)"
           name="add"
           _change={(newBody, newText) => {
             setBody(newBody)

--- a/packages/widget-projects/src/Widget.tsx
+++ b/packages/widget-projects/src/Widget.tsx
@@ -53,7 +53,7 @@ let Projects = () => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -125,7 +125,7 @@ let Snippets = () => {
     <>
       <Grid item style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid container direction="row" justifyContent="space-between">

--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -81,7 +81,7 @@ let Todo = () => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid

--- a/packages/widget-weather/src/Widget.tsx
+++ b/packages/widget-weather/src/Widget.tsx
@@ -164,7 +164,7 @@ const Weather = () => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid

--- a/packages/widget-welcome/src/Widget.tsx
+++ b/packages/widget-welcome/src/Widget.tsx
@@ -23,7 +23,7 @@ let Welcome = () => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid

--- a/packages/widget/src/ThirdPartyWidget.tsx
+++ b/packages/widget/src/ThirdPartyWidget.tsx
@@ -16,7 +16,7 @@ const ThirdPartyWidget = ({ name, label }: Props) => {
     <>
       <Grid item xs={1} style={{ maxWidth: '100%' }}>
         <Box sx={{
-          borderBottom: '1px solid var(--vscode-foreground)',
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
           padding: '8px',
         }}>
           <Grid


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (1 wk ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1653582143

### Workspace Type

Local Workspace

### What happened?


<img width="553" alt="image" src="https://user-images.githubusercontent.com/5144/170598147-f85e9526-10bb-4ddc-b0ce-6da40440c118.png">

The widget title divider / border can look more VS Codeish, see the difference between the stateful borders and marquee.

Stateful uses:
border: "var(--vscode-editorGroup-border)"

### What is your expected behavior?

_No response_

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues