### PR TITLE
[🐛 Bug]: Readme widget resizer icon not transparent

### DIFF
--- a/packages/gui/src/css/index.css
+++ b/packages/gui/src/css/index.css
@@ -22,3 +22,7 @@ a:hover {
 a:active {
   color: var(--vscode-textLink-foreground);
 }
+
+.splitter-layout .layout-pane::-webkit-scrollbar-corner {
+  background-color: transparent;
+}


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (1 wk ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1653582143

### Workspace Type

Local Workspace

### What happened?

At the bottom right of the readme widget you can see that the resizer isn't transparent. It doesn't hurt functionality, but it doesn't look great

<img width="696" alt="image" src="https://user-images.githubusercontent.com/5144/170559975-17d8a989-def2-48d5-8b2c-4c199e4935d8.png">


### What is your expected behavior?

_No response_

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues