### PR TITLE
[🐛 Bug]: MUI button secondary color hard to read

### DIFF
--- a/packages/gui/src/components/ModeSelector.tsx
+++ b/packages/gui/src/components/ModeSelector.tsx
@@ -86,6 +86,7 @@ const ModeSelector = () => {
           onClick={handleClick}
           size="small"
           disabled={disabled}
+          style={{background: 'transparent'}}
         >
           {!mode.icon && (
             <ViewCompactIcon fontSize="small" className="modeIcon" />
@@ -100,6 +101,7 @@ const ModeSelector = () => {
           aria-label="select merge strategy"
           aria-haspopup="menu"
           onClick={handleToggle}
+          style={{background: 'transparent'}}
         >
           <ArrowDropDownIcon />
         </Button>

--- a/packages/utils/src/calculateTheme.ts
+++ b/packages/utils/src/calculateTheme.ts
@@ -38,12 +38,26 @@ export default () => {
       MuiButton: {
         styleOverrides: {
           root: {
-            color: 'rgb(204, 204, 204)',
+            color: 'var(--vscode-button-foreground)',
+            backgroundColor: 'var(--vscode-button-background)',
             borderColor: 'var(--vscode-editorGhostText-foreground)',
             '&:hover': {
-              backgroundColor: 'var(--vscode-tree-tableOddRowsBackground)',
-              color: 'rgb(204, 204, 204)',
+              backgroundColor: 'var(--vscode-button-hoverBackground)',
               borderColor: 'var(--vscode-tab-inactiveForeground)'
+            }
+          },
+          outlined: {
+            backgroundColor: 'transparent',
+            color: 'var(--vscode-button-background)',
+          }
+        }
+      },
+      MuiListItem: {
+        styleOverrides: {
+          root: {
+            '&:hover': {
+              backgroundColor: 'var(--vscode-button-secondaryHoverBackground)',
+              color: 'var(--vscode-button-secondaryForeground)'
             }
           }
         }

--- a/packages/widget-notes/src/dialogs/AddDialog.tsx
+++ b/packages/widget-notes/src/dialogs/AddDialog.tsx
@@ -65,7 +65,7 @@ const AddDialog = React.memo(({ close }: { close: () => void }) => {
         />
       </DialogContent>
       <DialogActions style={{ paddingRight: theme.spacing(3) }}>
-        <Button onClick={close} color="secondary">
+        <Button onClick={close} color="secondary" style={{ padding: '4px 8px', margin: '0 5px' }}>
           Close
         </Button>
         {window.activeWorkspace

--- a/packages/widget-notes/src/dialogs/EditDialog.tsx
+++ b/packages/widget-notes/src/dialogs/EditDialog.tsx
@@ -71,7 +71,7 @@ const EditDialog = React.memo(({ close, note }: NoteEditDialogProps) => {
         />
       </DialogContent>
       <DialogActions style={{ paddingRight: theme.spacing(3) }}>
-        <Button onClick={close} color="secondary">
+        <Button onClick={close} color="secondary" style={{ padding: '4px 8px', margin: '0 5px' }}>
           Close
         </Button>
         <Button variant="contained" color="secondary" onClick={() => _removeNote(note.id)}>

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -140,7 +140,11 @@ let Snippets = () => {
                       size="small"
                       startIcon={<LinkIcon />}
                       disableFocusRipple
-                      style={{ padding: '0 5px' }}
+                      style={{
+                        padding: '0 5px',
+                        background: 'transparent',
+                        color: 'inherit'
+                      }}
                       onClick={() => jumpTo(snippet)}
                     >
                       {snippetLinkFileName}

--- a/packages/widget-todo/src/dialogs/AddDialog.tsx
+++ b/packages/widget-todo/src/dialogs/AddDialog.tsx
@@ -70,7 +70,7 @@ const TodoAddDialog = React.memo(({ close }: { close: () => void }) => {
         />
       </DialogContent>
       <DialogActions style={{ paddingRight: theme.spacing(3) }}>
-        <Button onClick={close} color="secondary">
+        <Button onClick={close} color="secondary" style={{ padding: '4px 8px', margin: '0 5px' }}>
           Close
         </Button>
         {window.activeWorkspace

--- a/packages/widget-todo/src/dialogs/EditDialog.tsx
+++ b/packages/widget-todo/src/dialogs/EditDialog.tsx
@@ -86,7 +86,7 @@ const TodoEditDialog = React.memo(({ close, todo }: TodoEditDialogParams) => {
         />
       </DialogContent>
       <DialogActions style={{ paddingRight: theme.spacing(3) }}>
-        <Button onClick={close} color="secondary">
+        <Button onClick={close} color="secondary" style={{ padding: '4px 8px', margin: '0 5px' }}>
           Close
         </Button>
         <Button variant="contained" color="secondary" onClick={() => _removeTodo(todo.id)}>


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (1 wk ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1653582143

### Workspace Type

Local Workspace

### What happened?

When you hover over MUI button elements in VS Code light themes it's shows that we're using a color there that makes it hard to read. Maybe there's another css variable that would be better? Or maybe nothings being passed down.

<img width="351" alt="image" src="https://user-images.githubusercontent.com/5144/170559288-3bcaa73d-e3b6-41bc-a130-90705990640c.png">


### What is your expected behavior?

_No response_

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues