### PR TITLE
Rename getOptionSelected to isOptionEqualToValue as part of MUI upgrade

### DIFF
--- a/packages/utils/src/components/BetterComplete.tsx
+++ b/packages/utils/src/components/BetterComplete.tsx
@@ -10,7 +10,7 @@ export interface Props {
   label: string
   variant: 'filled' | 'standard' | 'outlined' | undefined
   value: any
-  getOptionSelected: (option: any, value: any) => boolean
+  isOptionEqualToValue: (option: any, value: any) => boolean
   onChange: (e: ChangeEvent<{}>, v: any) => void
 }
 

--- a/packages/utils/tests/components/BetterComplete.test.tsx
+++ b/packages/utils/tests/components/BetterComplete.test.tsx
@@ -18,7 +18,7 @@ test('should show no options', async () => {
     options={options}
     value="foo"
     display='value'
-    getOptionSelected={jest.fn()}
+    isOptionEqualToValue={jest.fn()}
     onChange={jest.fn()}
   />)
   await userEvent.type(container.querySelector('input')!, 'lol')
@@ -34,7 +34,7 @@ test('should show options', async () => {
     options={options}
     value="foo"
     display='value'
-    getOptionSelected={jest.fn()}
+    isOptionEqualToValue={jest.fn()}
     onChange={jest.fn()}
   />)
   await userEvent.type(container.querySelector('input')!, 'foo')

--- a/packages/widget-github/src/components/TrendingDialog.tsx
+++ b/packages/widget-github/src/components/TrendingDialog.tsx
@@ -16,7 +16,7 @@ import TrendContext from '../Context'
 import { sinceOptions, trendLanguages, spokenLanguages } from '../constants'
 import type { Since, SpokenLanguage } from '../types'
 
-function getOptionSelected (defaultOption: { name: string }) {
+function isOptionEqualToValue (defaultOption: { name: string }) {
   return (option: SpokenLanguage, value: SpokenLanguage) => {
     if (!value) {
       return defaultOption.name === option.name
@@ -49,7 +49,7 @@ const SpokenLanguageOption = () => {
           options={spokenLanguages}
           display="name"
           value={value}
-          getOptionSelected={getOptionSelected(spokenLanguages[0])}
+          isOptionEqualToValue={isOptionEqualToValue(spokenLanguages[0])}
           onChange={(e: any, v: SpokenLanguage) => _updateSpoken(v)}
         />
       </Grid>
@@ -81,7 +81,7 @@ const ProgrammingLanguageOption = () => {
           options={trendLanguages}
           display="name"
           value={value}
-          getOptionSelected={getOptionSelected(trendLanguages[0])}
+          isOptionEqualToValue={isOptionEqualToValue(trendLanguages[0])}
           onChange={(e: any, v: SpokenLanguage) => _updateLanguage(v)}
         />
       </Grid>
@@ -113,7 +113,7 @@ const SinceOption = () => {
           options={sinceOptions}
           display="name"
           value={value}
-          getOptionSelected={getOptionSelected(sinceOptions[0])}
+          isOptionEqualToValue={isOptionEqualToValue(sinceOptions[0])}
           onChange={(e: any, v: Since) => _updateSince(v)}
         />
       </Grid>

--- a/packages/widget-weather/src/components/Dialog.tsx
+++ b/packages/widget-weather/src/components/Dialog.tsx
@@ -134,7 +134,7 @@ const ScaleOption = React.memo(() => {
           display="name"
           value={value}
           variant="filled"
-          getOptionSelected={(option, value) => {
+          isOptionEqualToValue={(option, value) => {
             return option.value === value.value
           }}
           onChange={(e, v) => v


### PR DESCRIPTION
This property was renamed as part of the [MUI upgrade](https://newreleases.io/project/github/mui/material-ui/release/v5.0.0-alpha.34).