### PR TITLE
[🐛 Bug]: Can't add Todo

### DIFF
--- a/packages/extension/tests/__mocks__/vscode.ts
+++ b/packages/extension/tests/__mocks__/vscode.ts
@@ -48,6 +48,8 @@ vscode.workspace = {
   name: 'foobarWorkspace',
   workspaceFile: { path: '/foo/bar' },
   getConfiguration: jest.fn().mockReturnValue({ get: jest.fn(), update: jest.fn() }),
+  onDidCloseTextDocument: jest.fn(),
+  onDidChangeTextDocument: jest.fn(),
   onDidChangeConfiguration: jest.fn(),
   fs: {
     readFile: jest.fn().mockResolvedValue('some file'),
@@ -66,6 +68,7 @@ vscode.window = {
   createOutputChannel: jest.fn().mockReturnValue({ appendLine: jest.fn() }),
   createTreeView: jest.fn().mockReturnValue({ reveal: jest.fn() }),
   onDidChangeActiveColorTheme: jest.fn(),
+  onDidChangeActiveTextEditor: jest.fn(),
   showOpenDialog: jest.fn().mockResolvedValue(['/foo/bar']),
   showErrorMessage: jest.fn(),
   showWarningMessage: jest.fn(),
@@ -86,6 +89,11 @@ vscode.window = {
   showTextDocument: jest.fn().mockResolvedValue({
     revealRange: jest.fn()
   })
+}
+
+vscode.languages = {
+  createDiagnosticCollection: jest.fn(),
+  registerCodeActionsProvider: jest.fn()
 }
 
 export default vscode

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -25,8 +25,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       vscode.commands.registerCommand('marquee.todo.move', this._moveTodo.bind(this)),
       vscode.commands.registerCommand('marquee.todo.add', this._addTodo.bind(this)),
       vscode.commands.registerCommand('marquee.todo.addEmpty', () => this.emit(
-        'openDialog', { event: 'openAddTodoDialog', payload: true
-        })),
+        'openDialog', { event: 'openAddTodoDialog', payload: true })),
       vscode.commands.registerTextEditorCommand('marquee.todo.addEditor', this._addEditor.bind(this)),
 
       /**
@@ -125,7 +124,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     }
 
     const path = `${vscode.window.activeTextEditor.document.uri.path}:${diagnostic.range.start.line}`
-    body = body.replace(/TODO[:]? /g, '').trim()
+    body = body.replace(TODO, '').trim()
 
     const todo: Todo = {
       archived: false,
@@ -141,6 +140,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     const newTodos = [todo].concat(this.state.todos)
     this.updateState('todos', newTodos)
     this.emit('gui.open')
+    this.broadcast({ todos: newTodos })
     vscode.commands.executeCommand('marquee.refreshCodeActions')
   }
 

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -7,7 +7,7 @@ import type { Configuration, State, Todo } from './types'
 
 const STATE_KEY = 'widgets.todo'
 export const CODE_TODO = 'marquee_todo'
-export const TODO = /(TODO|ToDo|Todo|todo)[:]? /g
+export const TODO = /(TODO|ToDo|Todo|todo)[:]? /
 
 export class TodoExtensionManager extends ExtensionManager<State, Configuration> {
   constructor (context: vscode.ExtensionContext, channel: vscode.OutputChannel) {

--- a/packages/widget-todo/tests/__snapshots__/extension.test.ts.snap
+++ b/packages/widget-todo/tests/__snapshots__/extension.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`_addTodo sets todo properly 1`] = `
+Array [
+  Array [
+    "todos",
+    Array [
+      Object {
+        "archived": false,
+        "body": "some new todo here",
+        "checked": false,
+        "id": "123457890",
+        "origin": "/some/path.js:123",
+        "path": "/some/path.js:123",
+        "tags": Array [],
+        "workspaceId": null,
+      },
+    ],
+  ],
+]
+`;
+
+exports[`_addTodo sets todo properly 2`] = `
+Array [
+  Array [
+    Object {
+      "todos": Array [
+        Object {
+          "archived": false,
+          "body": "some new todo here",
+          "checked": false,
+          "id": "123457890",
+          "origin": "/some/path.js:123",
+          "path": "/some/path.js:123",
+          "tags": Array [],
+          "workspaceId": null,
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`generate proper default state and configuration 1`] = `undefined`;
+
+exports[`generate proper default state and configuration 2`] = `
+Object {
+  "todos": Array [],
+}
+`;

--- a/packages/widget-todo/tests/extension.test.ts
+++ b/packages/widget-todo/tests/extension.test.ts
@@ -1,0 +1,87 @@
+import vscode from 'vscode'
+import { TodoExtensionManager } from '../src/extension'
+
+const context = {
+  globalState: {
+    setKeysForSync: jest.fn(),
+    get: jest.fn().mockReturnValue({ someRandomConfig: 'foobar' }),
+    update: jest.fn()
+  }
+}
+
+jest.mock('os', () => ({
+  platform: () => 'some platform',
+  release: () => 'some release'
+}))
+
+test('generate proper default state and configuration', () => {
+  const manager = new TodoExtensionManager(
+    context as any,
+    {} as any
+  )
+  expect(manager.configuration).toMatchSnapshot()
+  expect(manager.state).toMatchSnapshot()
+  expect(vscode.languages.createDiagnosticCollection).toBeCalledTimes(1)
+  expect(vscode.window.onDidChangeActiveTextEditor).toBeCalledWith(
+    expect.any(Function))
+  expect(vscode.workspace.onDidChangeTextDocument).toBeCalledWith(
+    expect.any(Function))
+  expect(vscode.workspace.onDidCloseTextDocument).toBeCalledWith(
+    expect.any(Function))
+})
+
+describe('_addTodo', () => {
+  beforeEach(() => {
+    // @ts-expect-error
+    const methodMock = jest.spyOn(TodoExtensionManager.prototype, '_refreshActiveTextEditor')
+    methodMock.mockImplementation() // no-op
+  })
+
+  it('with no active text editor', () => {
+    const manager = new TodoExtensionManager(
+      context as any,
+      {} as any
+    )
+    expect(manager['_addTodo']({} as any)).toBe(undefined)
+  })
+
+  it('with zero length body', () => {
+    const manager = new TodoExtensionManager(
+      context as any,
+      {} as any
+    )
+
+    vscode.window.activeTextEditor = {
+      document: {
+        getText: jest.fn().mockReturnValue(undefined)
+      }
+    } as any
+    expect(manager['_addTodo']({ range: 123 } as any)).toBe(undefined)
+    expect(vscode.window.activeTextEditor?.document.getText)
+      .toBeCalledWith(123)
+  })
+
+  it('sets todo properly', () => {
+    const manager = new TodoExtensionManager(
+      context as any,
+      {} as any
+    )
+
+    vscode.window.activeTextEditor = {
+      document: {
+        getText: jest.fn().mockReturnValue('ToDo: some new todo here'),
+        uri: { path: '/some/path.js' }
+      }
+    } as any
+    const diagnostic = {
+      range: { start: { line: 123 } },
+    } as any
+    expect(manager['_addTodo'](diagnostic)).toBe(undefined)
+    expect(vscode.commands.executeCommand)
+      .toBeCalledWith('marquee.refreshCodeActions')
+    expect(manager.emit).toBeCalledWith('gui.open')
+    expect((manager.updateState as jest.Mock).mock.calls).toMatchSnapshot()
+    // @ts-expect-error
+    expect((manager.broadcast as jest.Mock).mock.calls).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2 (Universal)
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.0.2

### Workspace Type

Local Workspace

### What happened?

Can't add todo, I do get the option to add it to marquee, but after selecting to add it does not show up in the todo list (workspace one or global)

### What is your expected behavior?

I expect the added to do to appear on the list of todos

### Relevant Log Output


https://user-images.githubusercontent.com/30395400/170893091-a01929bb-d7ca-4a59-a695-5153c065a740.mov



### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues