### PR TITLE
[🐛 Bug]: Checking todo's completed in tree fails

### DIFF
--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -137,6 +137,10 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
 
     this._channel.appendLine(`Update state "${prop.toString()}": ${val as any as string}`)
     this._state[prop] = val
+    await this.emitStateUpdate()
+  }
+
+  async emitStateUpdate () {
     await this._context.globalState.update(this._key, this._state)
     this.emit('stateUpdate', this._state)
   }

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -212,7 +212,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     }
 
     this.state.todos[todoIndex].checked = !item.checked
-    this.updateState('todos', this.state.todos)
+    this.emitStateUpdate()
     this.broadcast({ todos: this.state.todos })
   }
 
@@ -229,7 +229,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     }
 
     this.state.todos[todoIndex].archived = !item.archived
-    this.updateState('todos', this.state.todos)
+    this.emitStateUpdate()
     this.broadcast({ todos: this.state.todos })
   }
 
@@ -252,7 +252,7 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     }
 
     this.state.todos[todoIndex].workspaceId = awsp.id
-    this.updateState('todos', this.state.todos)
+    this.emitStateUpdate()
     this.broadcast({ todos: this.state.todos })
   }
 }


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (1 wk ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1653395108

### Workspace Type

Local Workspace

### What happened?

Click the check box, nothing happens.
<img width="426" alt="Screen Shot 2022-05-25 at 09 16 08" src="https://user-images.githubusercontent.com/5144/170311283-262dda7c-c719-4c68-8396-61f6fc03eb0d.png">


### What is your expected behavior?


Checked and updated both in tree and widget.

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues