### PR TITLE
[🐛 Bug]: Can't add to todo from code to Marquee

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,12 @@
         "enablement": "editorHasSelection"
       },
       {
+        "command": "marquee.todo.addEditor",
+        "title": "Add to Todos",
+        "category": "Marquee",
+        "enablement": "!editorHasSelection"
+      },
+      {
         "command": "marquee.todo.move",
         "title": "Move todo to current workspace",
         "category": "Marquee",


### PR DESCRIPTION
### VSCode Environment


Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (1 wk ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1653395108

### Workspace Type

Local Workspace

### What happened?

Options are grayed out.
<img width="469" alt="Screen Shot 2022-05-25 at 10 02 41" src="https://user-images.githubusercontent.com/5144/170320113-6fe77866-9466-4b1b-8ae4-99e8b52c26c3.png">



### What is your expected behavior?

Able to add todo!

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues