### PR TITLE
updated icons for showing global vs workspace mode

### DIFF
--- a/packages/gui/src/components/Navigation.tsx
+++ b/packages/gui/src/components/Navigation.tsx
@@ -24,6 +24,8 @@ import FeedbackDialog from '../dialogs/FeedbackDialog'
 import ThemeDialog from '../dialogs/ThemeDialog'
 import InfoDialog from '../dialogs/InfoDialog'
 import SettingsDialog from '../dialogs/SettingsDialog'
+import LanguageIcon from '@mui/icons-material/Language'
+import WorkspacesIcon from '@mui/icons-material/Workspaces'
 
 const PREFIX = 'Navigation'
 
@@ -271,7 +273,9 @@ const Navigation = () => {
                       overlap="circular"
                       badgeContent={globalScope ? 1 : 0}
                     >
-                      <FilterListIcon fontSize="small" />
+                      {globalScope ? 
+                        <LanguageIcon fontSize="small"/> : <WorkspacesIcon fontSize="small" />
+                      }
                     </Badge>
                   </IconButton>
                 </Tooltip>


### PR DESCRIPTION
For issue - https://github.com/stateful/vscode-marquee/issues/107

@christian-bromann Created a new branch and PR for this issue since I had worked on top of a previous branch. But this should work.

![marquee-globalvsworkspace](https://user-images.githubusercontent.com/63378463/171419768-76c03dc0-8b38-4ff9-a168-3bd6cfdb4448.gif)

