### PR TITLE
Prevent workspace changes to be stored globally

### DIFF
--- a/packages/extension/src/utils.ts
+++ b/packages/extension/src/utils.ts
@@ -66,9 +66,27 @@ class GUIExtensionManager extends ExtensionManager<State, Configuration> {
           delete val[modeName].icon.native
         }
       }
+
+      /**
+       * in order to prevent storing modes into the global workspace we should check weather
+       * they are part of the workspace settings
+       */
+      const workspaceFolder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0]
+      if (workspaceFolder) {
+        try {
+          const workspaceSettings: Record<string, any> = JSON.parse((await vscode.workspace.fs.readFile(
+            vscode.Uri.joinPath(workspaceFolder.uri, '.vscode', 'settings.json')
+          )).toString())
+          for (const workspaceMode of Object.keys(workspaceSettings['marquee.configuration.modes'])) {
+            delete val[workspaceMode]
+          }
+        } catch (err) {
+          // no-op
+        }
+      }
     }
 
-    super.updateConfiguration(prop, val)
+    return super.updateConfiguration(prop, val)
   }
 
   _onModeChange (event: vscode.ConfigurationChangeEvent) {

--- a/packages/extension/tests/utils.test.ts
+++ b/packages/extension/tests/utils.test.ts
@@ -49,7 +49,7 @@ test('activateGUI', () => {
   expect(extExport.marquee.disposable.state).toEqual('foobar')
 })
 
-test('extension manager removes native icon', () => {
+test('extension manager removes native icon', async () => {
   const context = {
     globalState: {
       get: jest.fn().mockReturnValue({}),
@@ -57,7 +57,7 @@ test('extension manager removes native icon', () => {
     }
   }
   const extExport = activateGUI(context as any, {} as any)
-  extExport.marquee.disposable.updateConfiguration('modes', {
+  await extExport.marquee.disposable.updateConfiguration('modes', {
     foobar: {
       icon: { foo: 'bar', native: 123 }
     }
@@ -65,6 +65,32 @@ test('extension manager removes native icon', () => {
   expect(extExport.marquee.disposable.configuration).toEqual({
     modes: {
       foobar: { icon: { foo: 'bar' } }
+    }
+  })
+})
+
+test('extension manager removes workspace modes', async () => {
+  const context = {
+    globalState: {
+      get: jest.fn().mockReturnValue({}),
+      setKeysForSync: jest.fn()
+    }
+  }
+  const extExport = activateGUI(context as any, {} as any)
+  // @ts-expect-error
+  vscode.workspace.workspaceFolders = ['/foo/bar']
+  ;(vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify({
+    'marquee.configuration.modes': { foobar: {} }
+  }))
+  await extExport.marquee.disposable.updateConfiguration('modes', {
+    default: {},
+    foobar: {
+      icon: { foo: 'bar', native: 123 }
+    }
+  })
+  expect(extExport.marquee.disposable.configuration).toEqual({
+    modes: {
+      default: {}
     }
   })
 })

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -29,7 +29,7 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
   constructor (
     protected _context: vscode.ExtensionContext,
     protected _channel: vscode.OutputChannel,
-    private _key: string,
+    protected _key: string,
     private _defaultConfiguration: Configuration,
     private _defaultState: State
   ) {


### PR DESCRIPTION
I've recognised that if someone has a local workspace settings file with some modes defined that they get later on stored globally. This patch prevents that from happening. I think however this applies to all configurations but not sure what the impact will be. With modes I think it is quite critical because if you switch around various workspaces that have their custom modes defined you will end up collecting them.