### PR TITLE
[🐛 Bug]: Error following treeview todo link

### DIFF
--- a/packages/extension/src/utils.ts
+++ b/packages/extension/src/utils.ts
@@ -142,11 +142,15 @@ export const linkMarquee = async (item: any) => {
     return
   }
 
-  const editor = await vscode.window.showTextDocument(doc)
-  const r = doc.lineAt(parseInt(ln)).range
-  if (!editor || !r) {
-    return
-  }
+  try {
+    const editor = await vscode.window.showTextDocument(doc)
+    const r = doc.lineAt(parseInt(ln)).range
+    if (!editor || !r) {
+      return
+    }
 
-  editor.revealRange(r, vscode.TextEditorRevealType.InCenter)
+    editor.revealRange(r, vscode.TextEditorRevealType.InCenter)
+  } catch (err: any) {
+    console.warn(`Marquee: ${(err as Error).message}`)
+  }
 }

--- a/packages/extension/tests/__mocks__/vscode.ts
+++ b/packages/extension/tests/__mocks__/vscode.ts
@@ -42,6 +42,8 @@ vscode.commands = {
   executeCommand: jest.fn()
 }
 
+const lineAtMock = jest.fn().mockReturnValue({ range: 'some range'})
+
 vscode.TreeItem = jest.fn()
 vscode.EventEmitter = jest.fn()
 vscode.workspace = {
@@ -56,8 +58,9 @@ vscode.workspace = {
     writeFile: jest.fn().mockResolvedValue({})
   },
   openTextDocument: jest.fn().mockResolvedValue({
-    lineAt: jest.fn().mockReturnValue({ range: 'some range'})
+    lineAt: lineAtMock
   }),
+  lineAtMock,
   registerTextDocumentContentProvider: jest.fn(),
   registerFileSystemProvider: jest.fn()
 }

--- a/packages/extension/tests/utils.test.ts
+++ b/packages/extension/tests/utils.test.ts
@@ -129,4 +129,12 @@ test('linkMarquee', async () => {
   expect(parse).toBeCalledWith('/some/file:123')
   await linkMarquee({ item: { origin: '/some/file:124' } })
   expect(parse).toBeCalledWith('/some/file')
+
+  // @ts-expect-error mock feature
+  vscode.workspace.lineAtMock.mockImplementation(() => {
+    throw new Error('ups')
+  })
+  const logSpy = jest.spyOn(console, 'warn')
+  await linkMarquee({ item: { origin: '/some/file:124' } })
+  expect(logSpy).toBeCalledWith('Marquee: ups')
 })


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (2 wks ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1654195685

### Workspace Type

Local Workspace

### What happened?

<img width="408" alt="Screen Shot 2022-06-02 at 13 28 03" src="https://user-images.githubusercontent.com/5144/171732429-f0fceca8-7e51-436b-a581-4463ad16017f.png">
<img width="597" alt="Screen Shot 2022-06-02 at 13 27 56" src="https://user-images.githubusercontent.com/5144/171732432-c990b30c-0300-4ce1-b6ca-0a7cf476d60f.png">

Clicking the link icon pops up the code editor but also this error.

### What is your expected behavior?

To open to the file and line if possible, otherwise maybe a message saying that "isn't available". This is from the global scope, so probably for a repo that doesn't have the file/line? Or maybe not anymore?

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues