### PR TITLE
each widget has a fullscreen button than can be toggled so the widget…

### DIFF
--- a/packages/widget-github/src/Widget.tsx
+++ b/packages/widget-github/src/Widget.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useMemo } from 'react'
-import { Grid, Link, Typography, Chip, Avatar, CircularProgress, Box } from '@mui/material'
+import React, { useContext, useMemo, useState } from 'react'
+import { Grid, Link, Typography, Chip, Avatar, CircularProgress, Dialog } from '@mui/material'
 import AvatarGroup from '@mui/material/AvatarGroup'
-import wrapper, { Dragger, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, ToggleFullScreen } from '@vscode-marquee/widget'
 import StarIcon from '@mui/icons-material/Star'
 import StarHalfIcon from '@mui/icons-material/StarHalf'
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord'
@@ -28,7 +28,7 @@ let GChip = ({ ...rest }) => {
 
 let Github = () => {
   const { trends, isFetching, error, trendFilter } = useContext(TrendContext)
-
+  const [fullscreenMode, setFullscreenMode] = useState(false)
   const filteredTrends = useMemo(() => {
     let filteredTrends = trends
 
@@ -44,22 +44,181 @@ let Github = () => {
 
     return filteredTrends
   }, [trends, trendFilter])
+  
+  const WidgetBody = () => (
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        <Grid item xs style={{ overflow: 'auto' }}>
+          {error && (
+            <Grid
+              item
+              xs
+              style={{
+                overflow: 'auto',
+                height: '100%',
+                width: '100%',
+                padding: '24px',
+              }}
+            >
+              <NetworkError message={error.message} />
+            </Grid>
+          )}
+          {isFetching && (
+            <Grid
+              container
+              style={{ height: '100%' }}
+              alignItems="center"
+              justifyContent="center"
+              direction="column"
+            >
+              <Grid item>
+                <CircularProgress color="secondary" />
+              </Grid>
+            </Grid>
+          )}
+          {!isFetching && !error && filteredTrends.length === 0 && (
+            <Grid
+              container
+              style={{ height: '100%' }}
+              alignItems="center"
+              justifyContent="center"
+              direction="column"
+            >
+              <Grid item>
+                <Typography variant="body2">
+                  There are no matches for your search criteria.
+                </Typography>
+              </Grid>
+            </Grid>
+          )}
+          {!isFetching && !error && filteredTrends.length !== 0 &&
+          filteredTrends.map((entry) => {
+            return (
+              <Grid
+                aria-labelledby="trend-entry"
+                key={entry.url}
+                container
+                direction="column"
+                sx={{
+                  marginTop: '4px',
+                  marginBottom: '4px',
+                  padding: '16px',
+                  borderBottom: '1px solid var(--vscode-editorGroup-border)',
+                }}
+              >
+                <Grid
+                  container
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <Grid item>
+                    <Link
+                      component="a"
+                      href={entry.url}
+                      target="_blank"
+                      underline="hover"
+                    >
+                      <Typography variant="body2">
+                        {entry.author}/{entry.name}
+                      </Typography>
+                    </Link>
+                  </Grid>
+                  <Grid item>
+                    <GChip
+                      label={entry.currentPeriodStars.toLocaleString()}
+                      icon={<StarHalfIcon />}
+                    />
+                  </Grid>
+                </Grid>
+                <Grid
+                  container
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                >
+                  <Grid item>
+                    <Typography variant="caption">
+                      {entry.description}
+                    </Typography>
+                  </Grid>
+                </Grid>
+                <Grid container>
+                  <Grid item>&nbsp;</Grid>
+                </Grid>
+                <Grid
+                  container
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="flex-end"
+                >
+                  <Grid item>
+                    <Grid container spacing={1}>
+                      {entry.language && (
+                        <Grid aria-label="language" item>
+                          <GChip
+                            label={entry.language}
+                            icon={
+                              <FiberManualRecordIcon
+                                style={{
+                                  fill: `${entry.languageColor}`,
+                                }}
+                              />
+                            }
+                          />
+                        </Grid>
+                      )}
+                      <Grid aria-label="forks" item>
+                        <GChip
+                          label={entry.forks.toLocaleString()}
+                          icon={<FontAwesomeIcon icon={faCodeBranch} />}
+                        />
+                      </Grid>
+                      <Grid aria-label="stars" item>
+                        <GChip
+                          label={entry.stars.toLocaleString()}
+                          icon={<StarIcon />}
+                        />
+                      </Grid>
+                    </Grid>
+                  </Grid>
+                  <Grid item>
+                    <AvatarGroup>
+                      {entry.builtBy.map((contributor) => {
+                        return (
+                          <Avatar
+                            key={contributor.username}
+                            style={{
+                              height: '22px',
+                              width: '22px',
+                              border: 0,
+                            }}
+                            src={contributor.avatar}
+                            alt={contributor.username}
+                          />
+                        )
+                      })}
+                    </AvatarGroup>
+                  </Grid>
+                </Grid>
+              </Grid>
+            )
+          })}
+        </Grid>
+      </Grid>
+    </Grid>
+  )
 
-  return (
-    <>
-      <Grid item style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
-          <Grid
-            container
-            direction="row"
-            wrap="nowrap"
-            alignItems="center"
-            alignContent="stretch"
-            justifyContent="space-between"
-          >
+  if(!fullscreenMode){
+    return (
+      <>
+        <HeaderWrapper>
+          <>
             <Grid item>
               <Typography variant="subtitle1">Trending on Github</Typography>
             </Grid>
@@ -75,181 +234,51 @@ let Github = () => {
                   <HidePop name="github" />
                 </Grid>
                 <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
                   <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          <Grid item xs style={{ overflow: 'auto' }}>
-            {error && (
-              <Grid
-                item
-                xs
-                style={{
-                  overflow: 'auto',
-                  height: '100%',
-                  width: '100%',
-                  padding: '24px',
-                }}
-              >
-                <NetworkError message={error.message} />
-              </Grid>
-            )}
-            {isFetching && (
-              <Grid
-                container
-                style={{ height: '100%' }}
-                alignItems="center"
-                justifyContent="center"
-                direction="column"
-              >
+          </>
+        </HeaderWrapper>
+        <WidgetBody />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <HeaderWrapper>
+          <>
+            <Grid item>
+              <Typography variant="subtitle1">Trending on Github</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1}>
                 <Grid item>
-                  <CircularProgress color="secondary" />
+                  <Filter />
+                </Grid>
+                <Grid item>
+                  <TrendingDialogLauncher />
+                </Grid>
+                <Grid item>
+                  <HidePop name="github" />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
                 </Grid>
               </Grid>
-            )}
-            {!isFetching && !error && filteredTrends.length === 0 && (
-              <Grid
-                container
-                style={{ height: '100%' }}
-                alignItems="center"
-                justifyContent="center"
-                direction="column"
-              >
-                <Grid item>
-                  <Typography variant="body2">
-                    There are no matches for your search criteria.
-                  </Typography>
-                </Grid>
-              </Grid>
-            )}
-            {!isFetching && !error && filteredTrends.length !== 0 &&
-              filteredTrends.map((entry) => {
-                return (
-                  <Grid
-                    aria-labelledby="trend-entry"
-                    key={entry.url}
-                    container
-                    direction="column"
-                    sx={{
-                      marginTop: '4px',
-                      marginBottom: '4px',
-                      padding: '16px',
-                      borderBottom: '1px solid var(--vscode-editorGroup-border)',
-                    }}
-                  >
-                    <Grid
-                      container
-                      direction="row"
-                      justifyContent="space-between"
-                      alignItems="center"
-                    >
-                      <Grid item>
-                        <Link
-                          component="a"
-                          href={entry.url}
-                          target="_blank"
-                          underline="hover"
-                        >
-                          <Typography variant="body2">
-                            {entry.author}/{entry.name}
-                          </Typography>
-                        </Link>
-                      </Grid>
-                      <Grid item>
-                        <GChip
-                          label={entry.currentPeriodStars.toLocaleString()}
-                          icon={<StarHalfIcon />}
-                        />
-                      </Grid>
-                    </Grid>
-                    <Grid
-                      container
-                      direction="row"
-                      justifyContent="space-between"
-                      alignItems="center"
-                    >
-                      <Grid item>
-                        <Typography variant="caption">
-                          {entry.description}
-                        </Typography>
-                      </Grid>
-                    </Grid>
-                    <Grid container>
-                      <Grid item>&nbsp;</Grid>
-                    </Grid>
-                    <Grid
-                      container
-                      direction="row"
-                      justifyContent="space-between"
-                      alignItems="flex-end"
-                    >
-                      <Grid item>
-                        <Grid container spacing={1}>
-                          {entry.language && (
-                            <Grid aria-label="language" item>
-                              <GChip
-                                label={entry.language}
-                                icon={
-                                  <FiberManualRecordIcon
-                                    style={{
-                                      fill: `${entry.languageColor}`,
-                                    }}
-                                  />
-                                }
-                              />
-                            </Grid>
-                          )}
-                          <Grid aria-label="forks" item>
-                            <GChip
-                              label={entry.forks.toLocaleString()}
-                              icon={<FontAwesomeIcon icon={faCodeBranch} />}
-                            />
-                          </Grid>
-                          <Grid aria-label="stars" item>
-                            <GChip
-                              label={entry.stars.toLocaleString()}
-                              icon={<StarIcon />}
-                            />
-                          </Grid>
-                        </Grid>
-                      </Grid>
-                      <Grid item>
-                        <AvatarGroup>
-                          {entry.builtBy.map((contributor) => {
-                            return (
-                              <Avatar
-                                key={contributor.username}
-                                style={{
-                                  height: '22px',
-                                  width: '22px',
-                                  border: 0,
-                                }}
-                                src={contributor.avatar}
-                                alt={contributor.username}
-                              />
-                            )
-                          })}
-                        </AvatarGroup>
-                      </Grid>
-                    </Grid>
-                  </Grid>
-                )
-              })}
-          </Grid>
-        </Grid>
-      </Grid>
-    </>
-  )
+            </Grid>
+          </>
+        </HeaderWrapper>
+        <WidgetBody />
+      </Dialog>
+    )
+  }
 }
 
 const Widget = () => (

--- a/packages/widget-github/src/Widget.tsx
+++ b/packages/widget-github/src/Widget.tsx
@@ -246,39 +246,38 @@ let Github = () => {
         <WidgetBody />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item>
-              <Typography variant="subtitle1">Trending on Github</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1}>
-                <Grid item>
-                  <Filter />
-                </Grid>
-                <Grid item>
-                  <TrendingDialogLauncher />
-                </Grid>
-                <Grid item>
-                  <HidePop name="github" />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+  } 
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item>
+            <Typography variant="subtitle1">Trending on Github</Typography>
+          </Grid>
+          <Grid item>
+            <Grid container direction="row" spacing={1}>
+              <Grid item>
+                <Filter />
+              </Grid>
+              <Grid item>
+                <TrendingDialogLauncher />
+              </Grid>
+              <Grid item>
+                <HidePop name="github" />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
               </Grid>
             </Grid>
-          </>
-        </HeaderWrapper>
-        <WidgetBody />
-      </Dialog>
-    )
-  }
+          </Grid>
+        </>
+      </HeaderWrapper>
+      <WidgetBody />
+    </Dialog>
+  )
 }
 
 const Widget = () => (

--- a/packages/widget-markdown/src/Widget.tsx
+++ b/packages/widget-markdown/src/Widget.tsx
@@ -210,27 +210,26 @@ const Markdown = () => {
         <MarkdownUIBody />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item>
-              <Typography variant="subtitle1">Markdown</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1} alignItems="center">
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
+  } 
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item>
+            <Typography variant="subtitle1">Markdown</Typography>
+          </Grid>
+          <Grid item>
+            <Grid container direction="row" spacing={1} alignItems="center">
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
               </Grid>
-            </Grid> 
-          </>
-        </HeaderWrapper>
-        <MarkdownUIBody />
-      </Dialog>
-    )
-  }
+            </Grid>
+          </Grid> 
+        </>
+      </HeaderWrapper>
+      <MarkdownUIBody />
+    </Dialog>
+  )
 }
 
 export default wrapper(

--- a/packages/widget-markdown/src/Widget.tsx
+++ b/packages/widget-markdown/src/Widget.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import {
   Box,
+  Dialog,
   Grid,
   ListItem,
   ListItemText,
@@ -8,7 +9,7 @@ import {
   Typography,
 } from '@mui/material'
 
-import wrapper, { Dragger, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, ToggleFullScreen } from '@vscode-marquee/widget'
 import SplitterLayout from 'react-splitter-layout'
 import ClearIcon from '@mui/icons-material/Clear'
 import { AutoSizer, List } from 'react-virtualized'
@@ -18,6 +19,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMarkdown } from '@fortawesome/free-brands-svg-icons/faMarkdown'
 
 const Markdown = () => {
+  const [fullscreenMode, setFullscreenMode] = useState(false)
   const [splitterSize, setSplitterSize] = useState(80)
   const [filter, setFilter] = useState('')
 
@@ -33,40 +35,10 @@ const Markdown = () => {
       md.name.toLowerCase().includes(filter.toLowerCase())
     )
     : markdownDocuments
+  
 
-  return (
-    <>
-      <Grid item style={{ maxWidth: '100%' }}>
-        <Box
-          sx={{
-            borderBottom: '1px solid var(--vscode-editorGroup-border)',
-            padding: '8px 8px 4px',
-          }}
-        >
-          <Grid
-            container
-            direction="row"
-            wrap="nowrap"
-            alignContent="stretch"
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Grid item>
-              <Typography variant="subtitle1">Markdown</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1} alignItems="center">
-                <Grid item>
-                  <HidePop name="markdown" />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-        </Box>
-      </Grid>
+  const MarkdownUIBody = () => {
+    return (
       <Grid item xs>
         <Grid
           container
@@ -210,8 +182,55 @@ const Markdown = () => {
           </Grid>
         </Grid>
       </Grid>
-    </>
-  )
+    )
+  }
+  if(!fullscreenMode) {
+    return (
+      <>
+        <HeaderWrapper>
+          <>
+            <Grid item>
+              <Typography variant="subtitle1">Markdown</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1} alignItems="center">
+                <Grid item>
+                  <HidePop name="markdown" />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
+                </Grid>
+              </Grid>
+            </Grid>
+          </>
+        </HeaderWrapper>  
+        <MarkdownUIBody />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <HeaderWrapper>
+          <>
+            <Grid item>
+              <Typography variant="subtitle1">Markdown</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1} alignItems="center">
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+              </Grid>
+            </Grid> 
+          </>
+        </HeaderWrapper>
+        <MarkdownUIBody />
+      </Dialog>
+    )
+  }
 }
 
 export default wrapper(

--- a/packages/widget-news/src/Widget.tsx
+++ b/packages/widget-news/src/Widget.tsx
@@ -158,34 +158,32 @@ let News = () => {
         <WidgetBody />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item>
-              <Typography variant="subtitle1">News</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1}>
-                <Grid item>
-                  <PopMenu value={data.channel} onChannelChange={(channel) => setData({ ...data, channel })} />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+  } 
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item>
+            <Typography variant="subtitle1">News</Typography>
+          </Grid>
+          <Grid item>
+            <Grid container direction="row" spacing={1}>
+              <Grid item>
+                <PopMenu value={data.channel} onChannelChange={(channel) => setData({ ...data, channel })} />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
               </Grid>
             </Grid>
-          </>
-        </HeaderWrapper>
-        <WidgetBody />
-      </Dialog>
-    )
-  }
-  
+          </Grid>
+        </>
+      </HeaderWrapper>
+      <WidgetBody />
+    </Dialog>
+  )
 }
 
 export default wrapper(News, 'news')

--- a/packages/widget-news/src/Widget.tsx
+++ b/packages/widget-news/src/Widget.tsx
@@ -6,14 +6,14 @@ import {
   ListItem,
   ListItemText,
   ListItemAvatar,
-  Box,
+  Dialog,
 } from '@mui/material'
 import Typography from '@mui/material/Typography'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faHackerNews } from '@fortawesome/free-brands-svg-icons/faHackerNews'
 import CircularProgress from '@mui/material/CircularProgress'
 
-import wrapper, { Dragger } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, ToggleFullScreen } from '@vscode-marquee/widget'
 import { NetworkError } from '@vscode-marquee/utils'
 
 import PopMenu from './components/Pop'
@@ -23,6 +23,7 @@ import type { WidgetState } from './types'
 
 let News = () => {
   const [data, setData] = useState(DEFAULT_STATE)
+  const [fullscreenMode, setFullscreenMode] = useState(false)
   useEffect(() => {
     let _setData = (data: WidgetState) => setData(data)
     setData({ ...data, isFetching: true })
@@ -30,19 +31,112 @@ let News = () => {
     return () => { _setData = () => {} }
   }, [data.channel])
 
-  return (
-    <>
-      <Grid item xs={1} style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
-          <Grid
-            container
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
-          >
+  const WidgetBody = () => (
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        <Grid item xs style={{ overflow: 'auto' }}>
+          {data.error && (
+            <Grid
+              item
+              xs
+              style={{
+                overflow: 'auto',
+                height: '100%',
+                width: '100%',
+                padding: '24px',
+              }}
+            >
+              <NetworkError message={data.error.message} />
+            </Grid>
+          )}
+          {data.isFetching && (
+            <Grid
+              container
+              style={{ height: '100%' }}
+              alignItems="center"
+              justifyContent="center"
+              direction="column"
+            >
+              <Grid item>
+                <CircularProgress color="secondary" />
+              </Grid>
+            </Grid>
+          )}
+          {!data.isFetching && data.news.length === 0 && (
+            <Grid
+              container
+              style={{ height: '100%' }}
+              alignItems="center"
+              justifyContent="center"
+              direction="column"
+            >
+              <Grid item>
+                No news available at the moment!
+              </Grid>
+            </Grid>
+          )}
+          {!data.isFetching && data.news.length !== 0 && (
+            <List dense={true}>
+              {data.news.map((entry) => (
+                <ListItem dense key={entry.id}>
+                  <ListItemAvatar>
+                    <Grid container justifyContent="center" alignItems="center">
+                      <Grid item>
+                        <FontAwesomeIcon icon={faHackerNews} />
+                      </Grid>
+                    </Grid>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={
+                      <>
+                        <Link
+                          component="a"
+                          href={`https://news.ycombinator.com/item?id=${entry.id}`}
+                          target="_blank"
+                          underline="hover">
+                          {entry.title}
+                        </Link>
+                        {entry.domain && (
+                          <Typography variant="caption">
+                            &nbsp;(
+                            <Link
+                              component="a"
+                              href={entry.url}
+                              target="_blank"
+                              underline="hover"
+                            >
+                              {entry.domain}
+                            </Link>
+                            )
+                          </Typography>
+                        )}
+                      </>
+                    }
+                    secondary={
+                      <Typography style={{ fontSize: '10px' }}>
+                        {entry.points} points by {entry.user} &nbsp;
+                        {entry.time_ago}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Grid>
+      </Grid>
+    </Grid>
+  )
+  if(!fullscreenMode){
+    return (
+      <>
+        <HeaderWrapper>
+          <>
             <Grid item>
               <Typography variant="subtitle1">News</Typography>
             </Grid>
@@ -52,114 +146,46 @@ let News = () => {
                   <PopMenu value={data.channel} onChannelChange={(channel) => setData({ ...data, channel })} />
                 </Grid>
                 <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
                   <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          <Grid item xs style={{ overflow: 'auto' }}>
-            {data.error && (
-              <Grid
-                item
-                xs
-                style={{
-                  overflow: 'auto',
-                  height: '100%',
-                  width: '100%',
-                  padding: '24px',
-                }}
-              >
-                <NetworkError message={data.error.message} />
-              </Grid>
-            )}
-            {data.isFetching && (
-              <Grid
-                container
-                style={{ height: '100%' }}
-                alignItems="center"
-                justifyContent="center"
-                direction="column"
-              >
+          </>
+        </HeaderWrapper>
+        <WidgetBody />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <HeaderWrapper>
+          <>
+            <Grid item>
+              <Typography variant="subtitle1">News</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1}>
                 <Grid item>
-                  <CircularProgress color="secondary" />
+                  <PopMenu value={data.channel} onChannelChange={(channel) => setData({ ...data, channel })} />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
                 </Grid>
               </Grid>
-            )}
-            {!data.isFetching && data.news.length === 0 && (
-              <Grid
-                container
-                style={{ height: '100%' }}
-                alignItems="center"
-                justifyContent="center"
-                direction="column"
-              >
-                <Grid item>
-                  No news available at the moment!
-                </Grid>
-              </Grid>
-            )}
-            {!data.isFetching && data.news.length !== 0 && (
-              <List dense={true}>
-                {data.news.map((entry) => (
-                  <ListItem dense key={entry.id}>
-                    <ListItemAvatar>
-                      <Grid container justifyContent="center" alignItems="center">
-                        <Grid item>
-                          <FontAwesomeIcon icon={faHackerNews} />
-                        </Grid>
-                      </Grid>
-                    </ListItemAvatar>
-                    <ListItemText
-                      primary={
-                        <>
-                          <Link
-                            component="a"
-                            href={`https://news.ycombinator.com/item?id=${entry.id}`}
-                            target="_blank"
-                            underline="hover">
-                            {entry.title}
-                          </Link>
-                          {entry.domain && (
-                            <Typography variant="caption">
-                              &nbsp;(
-                              <Link
-                                component="a"
-                                href={entry.url}
-                                target="_blank"
-                                underline="hover"
-                              >
-                                {entry.domain}
-                              </Link>
-                              )
-                            </Typography>
-                          )}
-                        </>
-                      }
-                      secondary={
-                        <Typography style={{ fontSize: '10px' }}>
-                          {entry.points} points by {entry.user} &nbsp;
-                          {entry.time_ago}
-                        </Typography>
-                      }
-                    />
-                  </ListItem>
-                ))}
-              </List>
-            )}
-          </Grid>
-        </Grid>
-      </Grid>
-    </>
-  )
+            </Grid>
+          </>
+        </HeaderWrapper>
+        <WidgetBody />
+      </Dialog>
+    )
+  }
+  
 }
 
 export default wrapper(News, 'news')

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -288,58 +288,57 @@ let Notes = () => {
         <WidgetBody note={note} notes={notes}/>
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item>
-              <Grid container direction="row" spacing={1} alignItems="center">
-                <Grid item>
-                  <Typography variant="subtitle1">Notes</Typography>
-                </Grid>
-                <Grid item>
-                  {note && noteLinkFileName && (
-                    <Button
-                      size="small"
-                      startIcon={<LinkIcon />}
-                      disableFocusRipple
-                      onClick={() => jumpTo(note)}
-                      style={{ padding: '0 5px' }}
-                    >
-                      {noteLinkFileName}
-                    </Button>
-                  )}
-                </Grid>
+  } 
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item>
+            <Grid container direction="row" spacing={1} alignItems="center">
+              <Grid item>
+                <Typography variant="subtitle1">Notes</Typography>
+              </Grid>
+              <Grid item>
+                {note && noteLinkFileName && (
+                  <Button
+                    size="small"
+                    startIcon={<LinkIcon />}
+                    disableFocusRipple
+                    onClick={() => jumpTo(note)}
+                    style={{ padding: '0 5px' }}
+                  >
+                    {noteLinkFileName}
+                  </Button>
+                )}
               </Grid>
             </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1} alignItems="center">
-                <Grid item>
-                  <IconButton size="small" onClick={() => setShowAddDialog(true)}>
-                    <AddCircleIcon fontSize="small" />
-                  </IconButton>
-                </Grid>
-                <Grid item>
-                  <DoubleClickHelper content="Double-click a note title to edit and right-click for copy & paste" />
-                </Grid>
-                <Grid item>
-                  <HidePop name="notes" />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+          </Grid>
+          <Grid item>
+            <Grid container direction="row" spacing={1} alignItems="center">
+              <Grid item>
+                <IconButton size="small" onClick={() => setShowAddDialog(true)}>
+                  <AddCircleIcon fontSize="small" />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <DoubleClickHelper content="Double-click a note title to edit and right-click for copy & paste" />
+              </Grid>
+              <Grid item>
+                <HidePop name="notes" />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
               </Grid>
             </Grid>
-          </>
-        </HeaderWrapper>
-        <WidgetBody note={note} notes={notes}/>
-      </Dialog>
-    )
-  }
+          </Grid>
+        </>
+      </HeaderWrapper>
+      <WidgetBody note={note} notes={notes}/>
+    </Dialog>
+  )
 }
 
 export default wrapper(() => (

--- a/packages/widget-projects/src/Widget.tsx
+++ b/packages/widget-projects/src/Widget.tsx
@@ -171,75 +171,74 @@ let Projects = () => {
         <ProjectWidgetBody />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item>
-              <Typography variant="subtitle1">Projects</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1}>
-                <Grid item>
-                  <ProjectsFilter />
-                </Grid>
-                <Grid item>
-                  <IconButton
-                    aria-label="Open Folder"
-                    size="small"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      window.vscode.postMessage({
-                        west: {
-                          execCommands: [{
-                            command: 'vscode.openFolder',
-                            options: { forceNewWindow: openProjectInNewWindow }
-                          }],
-                        },
-                      })
-                    }}
-                  >
-                    <AddCircle fontSize="small" />
-                  </IconButton>
-                </Grid>
-                <Grid item>
-                  <IconButton
-                    aria-label="Open Recent"
-                    size="small"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      window.vscode.postMessage({
-                        west: {
-                          execCommands: [
-                            {
-                              command: 'workbench.action.quickOpenRecent',
-                            },
-                          ],
-                        },
-                      })
-                    }}
-                  >
-                    <PageviewIcon fontSize="small" />
-                  </IconButton>
-                </Grid>
-                <Grid item>
-                  <ProjectPop />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+  } 
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item>
+            <Typography variant="subtitle1">Projects</Typography>
+          </Grid>
+          <Grid item>
+            <Grid container direction="row" spacing={1}>
+              <Grid item>
+                <ProjectsFilter />
+              </Grid>
+              <Grid item>
+                <IconButton
+                  aria-label="Open Folder"
+                  size="small"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    window.vscode.postMessage({
+                      west: {
+                        execCommands: [{
+                          command: 'vscode.openFolder',
+                          options: { forceNewWindow: openProjectInNewWindow }
+                        }],
+                      },
+                    })
+                  }}
+                >
+                  <AddCircle fontSize="small" />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <IconButton
+                  aria-label="Open Recent"
+                  size="small"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    window.vscode.postMessage({
+                      west: {
+                        execCommands: [
+                          {
+                            command: 'workbench.action.quickOpenRecent',
+                          },
+                        ],
+                      },
+                    })
+                  }}
+                >
+                  <PageviewIcon fontSize="small" />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <ProjectPop />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
               </Grid>
             </Grid>
-          </>
-        </HeaderWrapper>
-        <ProjectWidgetBody />
-      </Dialog>
-    )
-  }
+          </Grid>
+        </>
+      </HeaderWrapper>
+      <ProjectWidgetBody />
+    </Dialog>
+  )
 }
 
 const Widget = () => (

--- a/packages/widget-projects/src/Widget.tsx
+++ b/packages/widget-projects/src/Widget.tsx
@@ -1,9 +1,9 @@
-import React, { useContext, useMemo } from 'react'
-import { Grid, Typography, List, IconButton, Button, Box } from '@mui/material'
+import React, { useContext, useMemo, useState } from 'react'
+import { Grid, Typography, List, IconButton, Button, Dialog } from '@mui/material'
 import AddCircle from '@mui/icons-material/AddCircleOutlined'
 import PageviewIcon from '@mui/icons-material/Pageview'
 
-import wrapper, { Dragger } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, ToggleFullScreen } from '@vscode-marquee/widget'
 import { MarqueeWindow } from '@vscode-marquee/utils'
 
 import ProjectsFilter from './components/Filter'
@@ -18,6 +18,7 @@ let Projects = () => {
     notes, todos, snippets, workspaces, workspaceFilter,
     workspaceSortOrder, openProjectInNewWindow
   } = useContext(WorkspaceContext)
+  const [fullscreenMode, setFullscreenMode] = useState(false)
 
   const totalLen = (wspid: string) => {
     let todoCount = todos.filter(
@@ -48,21 +49,65 @@ let Projects = () => {
       return filteredProjects.sort((a, b) => a.name.localeCompare(b.name))
     }
   }, [workspaces, workspaceFilter, workspaceSortOrder])
+  const ProjectWidgetBody = () => (
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        <Grid item xs style={{ overflow: 'auto' }}>
+          {filteredProjects.length === 0 && (
+            <Grid
+              container
+              alignItems="center"
+              justifyContent="center"
+              style={{ height: '80%', width: '100%' }}
+            >
+              <Grid item>
+                <Button
+                  startIcon={<AddCircle />}
+                  variant="outlined"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    window.vscode.postMessage({
+                      west: {
+                        execCommands: [{
+                          command: 'vscode.openFolder',
+                          options: { forceNewWindow: openProjectInNewWindow }
+                        }],
+                      },
+                    })
+                  }}
+                >
+                  Add a project
+                </Button>
+              </Grid>
+            </Grid>
+          )}
+          {filteredProjects.length !== 0 && (
+            <List dense={true}>
+              {filteredProjects.map((workspace) => {
+                return (
+                  <ProjectListItem
+                    key={workspace.id}
+                    workspace={workspace}
+                  />
+                )
+              })}
+            </List>
+          )}
+        </Grid>
+      </Grid>
+    </Grid>
+  )
 
-  return (
-    <>
-      <Grid item xs={1} style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
-          <Grid
-            container
-            direction="row"
-            alignItems="center"
-            alignContent="stretch"
-            justifyContent="space-between"
-          >
+  if(!fullscreenMode){
+    return (
+      <>
+        <HeaderWrapper>
+          <>
             <Grid item>
               <Typography variant="subtitle1">Projects</Typography>
             </Grid>
@@ -114,32 +159,35 @@ let Projects = () => {
                   <ProjectPop />
                 </Grid>
                 <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
                   <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          <Grid item xs style={{ overflow: 'auto' }}>
-            {filteredProjects.length === 0 && (
-              <Grid
-                container
-                alignItems="center"
-                justifyContent="center"
-                style={{ height: '80%', width: '100%' }}
-              >
+          </>
+        </HeaderWrapper>
+        <ProjectWidgetBody />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <HeaderWrapper>
+          <>
+            <Grid item>
+              <Typography variant="subtitle1">Projects</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1}>
                 <Grid item>
-                  <Button
-                    startIcon={<AddCircle />}
-                    variant="outlined"
+                  <ProjectsFilter />
+                </Grid>
+                <Grid item>
+                  <IconButton
+                    aria-label="Open Folder"
+                    size="small"
                     onClick={(e) => {
                       e.preventDefault()
                       window.vscode.postMessage({
@@ -152,28 +200,46 @@ let Projects = () => {
                       })
                     }}
                   >
-                    Add a project
-                  </Button>
+                    <AddCircle fontSize="small" />
+                  </IconButton>
+                </Grid>
+                <Grid item>
+                  <IconButton
+                    aria-label="Open Recent"
+                    size="small"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      window.vscode.postMessage({
+                        west: {
+                          execCommands: [
+                            {
+                              command: 'workbench.action.quickOpenRecent',
+                            },
+                          ],
+                        },
+                      })
+                    }}
+                  >
+                    <PageviewIcon fontSize="small" />
+                  </IconButton>
+                </Grid>
+                <Grid item>
+                  <ProjectPop />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
                 </Grid>
               </Grid>
-            )}
-            {filteredProjects.length !== 0 && (
-              <List dense={true}>
-                {filteredProjects.map((workspace) => {
-                  return (
-                    <ProjectListItem
-                      key={workspace.id}
-                      workspace={workspace}
-                    />
-                  )
-                })}
-              </List>
-            )}
-          </Grid>
-        </Grid>
-      </Grid>
-    </>
-  )
+            </Grid>
+          </>
+        </HeaderWrapper>
+        <ProjectWidgetBody />
+      </Dialog>
+    )
+  }
 }
 
 const Widget = () => (

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -224,7 +224,6 @@ const WidgetBody = ({ snippets, snippet } : {snippets: Snippet[], snippet: Snipp
 
 let Snippets = () => {
   const eventListener = getEventListener<Events>(WIDGET_ID)
-  // const { globalScope } = useContext(GlobalContext)
   const [fullscreenMode, setFullscreenMode] = useState(false)
   const { snippets, snippetSelected} = useContext(SnippetContext)
 
@@ -237,71 +236,6 @@ let Snippets = () => {
       return snippet.origin.split('/').reverse()[0].toUpperCase()
     }
   }, [snippet])
-
-  // const snippetsArr = useMemo(() => {
-  //   let filteredItems = snippets
-
-  //   if (!globalScope) {
-  //     filteredItems = filteredItems.filter((item) => (
-  //       item.workspaceId && item.workspaceId === window.activeWorkspace?.id
-  //     ))
-  //   }
-
-  //   if (snippetFilter) {
-  //     filteredItems = filteredItems.filter((item) => (
-  //       item.title.toLowerCase().indexOf(snippetFilter.toLowerCase()) !== -1
-  //     ))
-  //   }
-
-  //   return filteredItems
-  // }, [globalScope, snippets, snippetFilter])
-
-  // useEffect(() => {
-  //   if (snippetsArr.length !== 0) {
-  //     setSnippetSelected(snippetsArr[0].id)
-  //   }
-  // }, [snippetFilter, globalScope])
-
-  // const snippetItemClick = useCallback((e: any, index: number) => {
-  //   if (e.detail === 1) {
-  //     if (snippetsArr[index] && snippetsArr[index].id) {
-  //       setSnippetSelected(snippetsArr[index].id)
-  //     } else {
-  //       console.error({
-  //         message:
-  //           'Trying to set selected snippet to an entry that doesn\'t exist in the array',
-  //         eventObj: e,
-  //       })
-  //     }
-  //   }
-
-  //   if (e.detail === 2) {
-  //     let path = snippetsArr[index].path || ''
-  //     /**
-  //      * transform v2 snippets to make them editable in v3
-  //      */
-  //     if (!path.startsWith('/')) {
-  //       path = `/${snippetsArr[index].id}/${path}`
-  //     }
-
-  //     return eventListener.emit('openSnippet', path)
-  //   }
-  // }, [snippetsArr])
-
-  // const rowRenderer = ({ key, index, style }: RowRendererProps) => {
-  //   const snippetEntry = snippetsArr[index]
-  //   return (
-  //     <SnippetListItem
-  //       key={key}
-  //       keyVal={key}
-  //       index={index}
-  //       style={style}
-  //       snippet={snippetEntry}
-  //       selected={snippetSelected}
-  //       click={snippetItemClick}
-  //     />
-  //   )
-  // }
 
   if(!fullscreenMode){
     return (
@@ -361,65 +295,64 @@ let Snippets = () => {
         <WidgetBody snippet={snippet} snippets={snippets}/>
       </>
     )
-  }else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item>
-              <Grid container direction="row" spacing={1} alignItems="center">
-                <Grid item>
-                  <Typography variant="subtitle1">Snippets</Typography>
-                </Grid>
-                <Grid item>
-                  {snippet && snippetLinkFileName && (
-                    <Button
-                      size="small"
-                      startIcon={<LinkIcon />}
-                      disableFocusRipple
-                      style={{
-                        padding: '0 5px',
-                        background: 'transparent',
-                        color: 'inherit'
-                      }}
-                      onClick={() => jumpTo(snippet)}
-                    >
-                      {snippetLinkFileName}
-                    </Button>
-                  )}
-                </Grid>
-              </Grid>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1} alignItems="center">
-                <Grid item>
-                  <IconButton
-                    size="small"
-                    onClick={() => eventListener.emit('openSnippet', '/New Snippet')}
-                  >
-                    <AddCircle fontSize="small" />
-                  </IconButton>
-                </Grid>
-                <Grid item>
-                  <DoubleClickHelper content="Double-click a snippet title to edit and right-click for copy & paste" />
-                </Grid>
-                <Grid item>
-                  <HidePop name="snippets" />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
-              </Grid>
-            </Grid>
-          </>
-        </HeaderWrapper>
-        <WidgetBody snippet={snippet} snippets={snippets}/>
-      </Dialog>
-    )
   }
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item>
+            <Grid container direction="row" spacing={1} alignItems="center">
+              <Grid item>
+                <Typography variant="subtitle1">Snippets</Typography>
+              </Grid>
+              <Grid item>
+                {snippet && snippetLinkFileName && (
+                  <Button
+                    size="small"
+                    startIcon={<LinkIcon />}
+                    disableFocusRipple
+                    style={{
+                      padding: '0 5px',
+                      background: 'transparent',
+                      color: 'inherit'
+                    }}
+                    onClick={() => jumpTo(snippet)}
+                  >
+                    {snippetLinkFileName}
+                  </Button>
+                )}
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <Grid container direction="row" spacing={1} alignItems="center">
+              <Grid item>
+                <IconButton
+                  size="small"
+                  onClick={() => eventListener.emit('openSnippet', '/New Snippet')}
+                >
+                  <AddCircle fontSize="small" />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <DoubleClickHelper content="Double-click a snippet title to edit and right-click for copy & paste" />
+              </Grid>
+              <Grid item>
+                <HidePop name="snippets" />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
+              </Grid>
+            </Grid>
+          </Grid>
+        </>
+      </HeaderWrapper>
+      <WidgetBody snippet={snippet} snippets={snippets}/>
+    </Dialog>
+  )
 }
 
 export default wrapper(() => (

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -1,16 +1,16 @@
-import React, { useContext, useEffect, useMemo, useCallback } from 'react'
+import React, { useContext, useEffect, useMemo, useCallback, useState } from 'react'
 import {
   Grid,
   IconButton,
   Typography,
   TextField,
   Button,
-  Box,
+  Dialog,
 } from '@mui/material'
 
 import { AddCircle, Clear } from '@mui/icons-material'
 import LinkIcon from '@mui/icons-material/Link'
-import wrapper, { Dragger, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, ToggleFullScreen } from '@vscode-marquee/widget'
 import { GlobalContext, jumpTo, DoubleClickHelper, MarqueeWindow, getEventListener } from '@vscode-marquee/utils'
 
 import SplitterLayout from 'react-splitter-layout'
@@ -23,6 +23,7 @@ import SnippetContext, { SnippetProvider } from './Context'
 import SnippetListItem from './components/ListItem'
 import { WIDGET_ID } from './constants'
 import type { Events } from './types'
+import Snippet from './models/Snippet'
 
 declare const window: MarqueeWindow
 
@@ -32,29 +33,17 @@ interface RowRendererProps {
   style: object
 }
 
-let Snippets = () => {
+const WidgetBody = ({ snippets, snippet } : {snippets: Snippet[], snippet: Snippet | undefined}) =>  {
   const eventListener = getEventListener<Events>(WIDGET_ID)
   const { globalScope } = useContext(GlobalContext)
-
   const {
     setSnippetFilter,
     setSnippetSelected,
     setSnippetSplitter,
-    snippets,
     snippetFilter,
     snippetSelected,
     snippetSplitter,
   } = useContext(SnippetContext)
-
-  const snippet = useMemo(() => {
-    return snippets.find((snippet) => snippet.id === snippetSelected)
-  }, [snippetSelected, snippets])
-
-  const snippetLinkFileName = useMemo(() => {
-    if (snippet && snippet.origin) {
-      return snippet.origin.split('/').reverse()[0].toUpperCase()
-    }
-  }, [snippet])
 
   const snippetsArr = useMemo(() => {
     let filteredItems = snippets
@@ -120,20 +109,205 @@ let Snippets = () => {
       />
     )
   }
-
+  
   return (
-    <>
-      <Grid item style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
-          <Grid
-            container
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        <Grid item xs style={{ overflow: 'hidden' }}>
+          <SplitterLayout
+            percentage={true}
+            primaryIndex={0}
+            secondaryMinSize={10}
+            primaryMinSize={10}
+            secondaryInitialSize={snippetSplitter || 80}
+            onSecondaryPaneSizeChange={setSnippetSplitter}
           >
+            <div
+              style={{
+                height: '100%',
+                overflow: 'hidden',
+              }}
+            >
+              <Grid
+                container
+                wrap="nowrap"
+                direction="column"
+                style={{
+                  height: '100%',
+                  overflow: 'hidden',
+                }}
+              >
+                <Grid item style={{ maxWidth: '100%', padding: '8px' }}>
+                  <TextField
+                    margin="dense"
+                    placeholder="Filter..."
+                    fullWidth
+                    size="small"
+                    value={snippetFilter}
+                    onChange={(e) => setSnippetFilter(e.target.value)}
+                    InputProps={{
+                      endAdornment: (
+                        <Clear
+                          fontSize="small"
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => setSnippetFilter('') }
+                        />
+                      ),
+                    }}
+                  />
+                </Grid>
+                <Grid item xs style={{ maxWidth: '100%' }}>
+                  <AutoSizer>
+                    {({ height, width }) => (
+                      <List
+                        width={width}
+                        height={height}
+                        rowCount={snippetsArr.length}
+                        rowHeight={30}
+                        rowRenderer={rowRenderer}
+                      />
+                    )}
+                  </AutoSizer>
+                </Grid>
+              </Grid>
+            </div>
+            <div style={{ height: '100%' }}>
+              <Grid container style={{ width: '100%', height: '100%' }}>
+                <Grid
+                  item
+                  style={{
+                    height: '100%',
+                    width: '100%',
+                    overflow: 'auto',
+                  }}
+                >
+                  {snippetsArr.length === 0 && (
+                    <Grid
+                      container
+                      style={{ height: '100%' }}
+                      alignItems="center"
+                      justifyContent="center"
+                      direction="column"
+                    >
+                      <Grid item>
+                        <Typography>Nothing here yet.</Typography>
+                      </Grid>
+                      <Grid item>&nbsp;</Grid>
+                      <Grid item>
+                        <Button
+                          startIcon={<AddCircle />}
+                          variant="outlined"
+                          onClick={() => eventListener.emit('openSnippet', '/New Snippet')}
+                        >
+                          Create a snippet
+                        </Button>
+                      </Grid>
+                    </Grid>
+                  )}
+                  {snippetsArr.length !== 0 && snippet && (
+                    <pre style={{ paddingLeft: 15, paddingRight: 15 }}>{snippet.body}</pre>
+                  )}
+                </Grid>
+              </Grid>
+            </div>
+          </SplitterLayout>
+        </Grid>
+      </Grid>
+    </Grid>
+  )
+}
+
+let Snippets = () => {
+  const eventListener = getEventListener<Events>(WIDGET_ID)
+  // const { globalScope } = useContext(GlobalContext)
+  const [fullscreenMode, setFullscreenMode] = useState(false)
+  const { snippets, snippetSelected} = useContext(SnippetContext)
+
+  const snippet = useMemo(() => {
+    return snippets.find((snippet) => snippet.id === snippetSelected)
+  }, [snippetSelected, snippets])
+
+  const snippetLinkFileName = useMemo(() => {
+    if (snippet && snippet.origin) {
+      return snippet.origin.split('/').reverse()[0].toUpperCase()
+    }
+  }, [snippet])
+
+  // const snippetsArr = useMemo(() => {
+  //   let filteredItems = snippets
+
+  //   if (!globalScope) {
+  //     filteredItems = filteredItems.filter((item) => (
+  //       item.workspaceId && item.workspaceId === window.activeWorkspace?.id
+  //     ))
+  //   }
+
+  //   if (snippetFilter) {
+  //     filteredItems = filteredItems.filter((item) => (
+  //       item.title.toLowerCase().indexOf(snippetFilter.toLowerCase()) !== -1
+  //     ))
+  //   }
+
+  //   return filteredItems
+  // }, [globalScope, snippets, snippetFilter])
+
+  // useEffect(() => {
+  //   if (snippetsArr.length !== 0) {
+  //     setSnippetSelected(snippetsArr[0].id)
+  //   }
+  // }, [snippetFilter, globalScope])
+
+  // const snippetItemClick = useCallback((e: any, index: number) => {
+  //   if (e.detail === 1) {
+  //     if (snippetsArr[index] && snippetsArr[index].id) {
+  //       setSnippetSelected(snippetsArr[index].id)
+  //     } else {
+  //       console.error({
+  //         message:
+  //           'Trying to set selected snippet to an entry that doesn\'t exist in the array',
+  //         eventObj: e,
+  //       })
+  //     }
+  //   }
+
+  //   if (e.detail === 2) {
+  //     let path = snippetsArr[index].path || ''
+  //     /**
+  //      * transform v2 snippets to make them editable in v3
+  //      */
+  //     if (!path.startsWith('/')) {
+  //       path = `/${snippetsArr[index].id}/${path}`
+  //     }
+
+  //     return eventListener.emit('openSnippet', path)
+  //   }
+  // }, [snippetsArr])
+
+  // const rowRenderer = ({ key, index, style }: RowRendererProps) => {
+  //   const snippetEntry = snippetsArr[index]
+  //   return (
+  //     <SnippetListItem
+  //       key={key}
+  //       keyVal={key}
+  //       index={index}
+  //       style={style}
+  //       snippet={snippetEntry}
+  //       selected={snippetSelected}
+  //       click={snippetItemClick}
+  //     />
+  //   )
+  // }
+
+  if(!fullscreenMode){
+    return (
+      <>
+        <HeaderWrapper>
+          <>
             <Grid item>
               <Grid container direction="row" spacing={1} alignItems="center">
                 <Grid item>
@@ -175,123 +349,77 @@ let Snippets = () => {
                   <HidePop name="snippets" />
                 </Grid>
                 <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
                   <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          <Grid item xs style={{ overflow: 'hidden' }}>
-            <SplitterLayout
-              percentage={true}
-              primaryIndex={0}
-              secondaryMinSize={10}
-              primaryMinSize={10}
-              secondaryInitialSize={snippetSplitter || 80}
-              onSecondaryPaneSizeChange={setSnippetSplitter}
-            >
-              <div
-                style={{
-                  height: '100%',
-                  overflow: 'hidden',
-                }}
-              >
-                <Grid
-                  container
-                  wrap="nowrap"
-                  direction="column"
-                  style={{
-                    height: '100%',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <Grid item style={{ maxWidth: '100%', padding: '8px' }}>
-                    <TextField
-                      margin="dense"
-                      placeholder="Filter..."
-                      fullWidth
+          </>
+        </HeaderWrapper>
+        <WidgetBody snippet={snippet} snippets={snippets}/>
+      </>
+    )
+  }else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <HeaderWrapper>
+          <>
+            <Grid item>
+              <Grid container direction="row" spacing={1} alignItems="center">
+                <Grid item>
+                  <Typography variant="subtitle1">Snippets</Typography>
+                </Grid>
+                <Grid item>
+                  {snippet && snippetLinkFileName && (
+                    <Button
                       size="small"
-                      value={snippetFilter}
-                      onChange={(e) => setSnippetFilter(e.target.value)}
-                      InputProps={{
-                        endAdornment: (
-                          <Clear
-                            fontSize="small"
-                            style={{ cursor: 'pointer' }}
-                            onClick={() => setSnippetFilter('') }
-                          />
-                        ),
+                      startIcon={<LinkIcon />}
+                      disableFocusRipple
+                      style={{
+                        padding: '0 5px',
+                        background: 'transparent',
+                        color: 'inherit'
                       }}
-                    />
-                  </Grid>
-                  <Grid item xs style={{ maxWidth: '100%' }}>
-                    <AutoSizer>
-                      {({ height, width }) => (
-                        <List
-                          width={width}
-                          height={height}
-                          rowCount={snippetsArr.length}
-                          rowHeight={30}
-                          rowRenderer={rowRenderer}
-                        />
-                      )}
-                    </AutoSizer>
-                  </Grid>
+                      onClick={() => jumpTo(snippet)}
+                    >
+                      {snippetLinkFileName}
+                    </Button>
+                  )}
                 </Grid>
-              </div>
-              <div style={{ height: '100%' }}>
-                <Grid container style={{ width: '100%', height: '100%' }}>
-                  <Grid
-                    item
-                    style={{
-                      height: '100%',
-                      width: '100%',
-                      overflow: 'auto',
-                    }}
+              </Grid>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1} alignItems="center">
+                <Grid item>
+                  <IconButton
+                    size="small"
+                    onClick={() => eventListener.emit('openSnippet', '/New Snippet')}
                   >
-                    {snippetsArr.length === 0 && (
-                      <Grid
-                        container
-                        style={{ height: '100%' }}
-                        alignItems="center"
-                        justifyContent="center"
-                        direction="column"
-                      >
-                        <Grid item>
-                          <Typography>Nothing here yet.</Typography>
-                        </Grid>
-                        <Grid item>&nbsp;</Grid>
-                        <Grid item>
-                          <Button
-                            startIcon={<AddCircle />}
-                            variant="outlined"
-                            onClick={() => eventListener.emit('openSnippet', '/New Snippet')}
-                          >
-                            Create a snippet
-                          </Button>
-                        </Grid>
-                      </Grid>
-                    )}
-                    {snippetsArr.length !== 0 && snippet && (
-                      <pre style={{ paddingLeft: 15, paddingRight: 15 }}>{snippet.body}</pre>
-                    )}
-                  </Grid>
+                    <AddCircle fontSize="small" />
+                  </IconButton>
                 </Grid>
-              </div>
-            </SplitterLayout>
-          </Grid>
-        </Grid>
-      </Grid>
-    </>
-  )
+                <Grid item>
+                  <DoubleClickHelper content="Double-click a snippet title to edit and right-click for copy & paste" />
+                </Grid>
+                <Grid item>
+                  <HidePop name="snippets" />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
+                </Grid>
+              </Grid>
+            </Grid>
+          </>
+        </HeaderWrapper>
+        <WidgetBody snippet={snippet} snippets={snippets}/>
+      </Dialog>
+    )
+  }
 }
 
 export default wrapper(() => (

--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -184,45 +184,44 @@ let Todo = () => {
         <TodoUIBody />  
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item xs={4}>
-              <Typography variant="subtitle1">Todo <TodoInfo /></Typography>
-            </Grid>
+  } 
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item xs={4}>
+            <Typography variant="subtitle1">Todo <TodoInfo /></Typography>
+          </Grid>
 
-            <Grid item xs={8}>
-              <Grid container justifyContent="right" direction="row" spacing={1}>
-                <Grid item>
-                  <TodoFilter />
-                </Grid>
-                <Grid item>
-                  <IconButton aria-label="add-todo" size="small" onClick={() => setShowAddDialog(true)}>
-                    <AddCircle fontSize="small" />
-                  </IconButton>
-                </Grid>
-                <Grid item>
-                  <DoubleClickHelper />
-                </Grid>
-                <Grid item>
-                  <TodoPop />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+          <Grid item xs={8}>
+            <Grid container justifyContent="right" direction="row" spacing={1}>
+              <Grid item>
+                <TodoFilter />
+              </Grid>
+              <Grid item>
+                <IconButton aria-label="add-todo" size="small" onClick={() => setShowAddDialog(true)}>
+                  <AddCircle fontSize="small" />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <DoubleClickHelper />
+              </Grid>
+              <Grid item>
+                <TodoPop />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
               </Grid>
             </Grid>
-          </>
-        </HeaderWrapper>   
-        <TodoUIBody />
-      </Dialog>
-    )
-  }
+          </Grid>
+        </>
+      </HeaderWrapper>   
+      <TodoUIBody />
+    </Dialog>
+  )
 }
 
 const Widget = () => (

--- a/packages/widget-weather/src/Widget.tsx
+++ b/packages/widget-weather/src/Widget.tsx
@@ -1,19 +1,23 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 
 // @ts-expect-error no types available
 import WeatherIcon from 'react-icons-weather'
-import { Grid, Typography, CircularProgress, Box } from '@mui/material'
+import { Grid, Typography, CircularProgress, Box, Dialog } from '@mui/material'
 
 import { GlobalContext, NetworkError } from '@vscode-marquee/utils'
-import wrapper, { Dragger, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HidePop, HeaderWrapper, ToggleFullScreen } from '@vscode-marquee/widget'
 
 import WeatherContext, { WeatherProvider } from './Context'
 import { WeatherDialogLauncher } from './components/Dialog'
 import { kToF, kToC, formatAMPM } from './utils'
 import { SCALE_OPTIONS } from './constants'
 import type { Forecast } from './types'
-
-let Today = React.memo(({ current, hourly }: Pick<Forecast, 'current' | 'hourly'>) => {
+interface TodayPropTypes {
+  current: Forecast['current']
+  hourly: Forecast['hourly']
+  fullscreenMode: boolean
+}
+let Today = React.memo(({ current, hourly, fullscreenMode } : TodayPropTypes ) => {
   const { scale } = useContext(WeatherContext)
   const { themeColor } = useContext(GlobalContext)
 
@@ -41,7 +45,7 @@ let Today = React.memo(({ current, hourly }: Pick<Forecast, 'current' | 'hourly'
               iconId={`${current.weather[0].id}`}
               flip="horizontal"
               rotate="90"
-              style={{ fontSize: '75px' }}
+              style={{ fontSize: fullscreenMode ? '300px' : '75px'}}
             />
           </Grid>
           <Grid item>
@@ -159,22 +163,64 @@ let Today = React.memo(({ current, hourly }: Pick<Forecast, 'current' | 'hourly'
 
 const Weather = () => {
   const { city, forecast, error, isFetching } = useContext(WeatherContext)
+  const [fullscreenMode, setFullscreenMode] = useState(false)
 
-  return (
-    <>
-      <Grid item xs={1} style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
+  const WidgetBody = () => (
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        {error && (
+          <Grid
+            item
+            xs
+            style={{
+              overflow: 'auto',
+              height: '100%',
+              width: '100%',
+              padding: '24px',
+            }}
+          >
+            <NetworkError message={error.message} />
+          </Grid>
+        )}
+        {!error && isFetching && (
           <Grid
             container
-            direction="row"
-            justifyContent="space-between"
+            style={{ height: '100%' }}
             alignItems="center"
-            flexWrap="nowrap"
-            minWidth={0}
+            justifyContent="center"
+            direction="column"
           >
+            <Grid item>
+              <CircularProgress color="secondary" />
+            </Grid>
+          </Grid>
+        )}
+        {!error && !isFetching && forecast && (<Grid
+          item
+          xs
+          style={{
+            overflow: 'auto',
+            height: '100%',
+            width: '100%',
+            padding: '24px',
+          }}
+        >
+          <Today current={forecast.current} hourly={forecast.hourly} fullscreenMode={fullscreenMode}/>
+        </Grid>)}
+      </Grid>
+    </Grid>
+  )
+
+  if(!fullscreenMode){
+    return (
+      <>
+        <HeaderWrapper>
+          <>
             <Grid item xs={8} style={{
               flexBasis: 'auto',
               whiteSpace: 'nowrap',
@@ -198,63 +244,60 @@ const Weather = () => {
                   <HidePop name="weather" />
                 </Grid>
                 <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
                   <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          {error && (
-            <Grid
-              item
-              xs
-              style={{
-                overflow: 'auto',
-                height: '100%',
-                width: '100%',
-                padding: '24px',
-              }}
-            >
-              <NetworkError message={error.message} />
+          </>
+        </HeaderWrapper>
+        <WidgetBody />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <HeaderWrapper>
+          <>
+            <Grid item xs={8} style={{
+              flexBasis: 'auto',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis'
+            }}>
+              {city && (
+                <Typography variant="subtitle1">
+                  Weather in{' '}
+                  {city.replace(', United States', '').replace(', USA', '')}
+                </Typography>
+              )}
+              {!city && <Typography variant="subtitle1">Weather</Typography>}
             </Grid>
-          )}
-          {!error && isFetching && (
-            <Grid
-              container
-              style={{ height: '100%' }}
-              alignItems="center"
-              justifyContent="center"
-              direction="column"
-            >
-              <Grid item>
-                <CircularProgress color="secondary" />
+            <Grid item xs={4} style={{ minWidth: 105 }}>
+              <Grid container direction="row" spacing={1} justifyContent="flex-end">
+                <Grid item>
+                  <WeatherDialogLauncher />
+                </Grid>
+                <Grid item>
+                  <HidePop name="weather" />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
+                </Grid>
               </Grid>
             </Grid>
-          )}
-          {!error && !isFetching && forecast && (<Grid
-            item
-            xs
-            style={{
-              overflow: 'auto',
-              height: '100%',
-              width: '100%',
-              padding: '24px',
-            }}
-          >
-            <Today current={forecast.current} hourly={forecast.hourly} />
-          </Grid>)}
-        </Grid>
-      </Grid>
-    </>
-  )
+          </>
+        </HeaderWrapper>
+        <WidgetBody />
+      </Dialog>
+    )
+  }
+  
 }
 
 export default wrapper(() => (

--- a/packages/widget-weather/src/Widget.tsx
+++ b/packages/widget-weather/src/Widget.tsx
@@ -263,48 +263,46 @@ const Weather = () => {
         <WidgetBody />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <HeaderWrapper>
-          <>
-            <Grid item xs={8} style={{
-              flexBasis: 'auto',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis'
-            }}>
-              {city && (
-                <Typography variant="subtitle1">
-                  Weather in{' '}
-                  {city.replace(', United States', '').replace(', USA', '')}
-                </Typography>
-              )}
-              {!city && <Typography variant="subtitle1">Weather</Typography>}
-            </Grid>
-            <Grid item xs={4} style={{ minWidth: 105 }}>
-              <Grid container direction="row" spacing={1} justifyContent="flex-end">
-                <Grid item>
-                  <WeatherDialogLauncher />
-                </Grid>
-                <Grid item>
-                  <HidePop name="weather" />
-                </Grid>
-                <Grid item>
-                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+  }
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <HeaderWrapper>
+        <>
+          <Grid item xs={8} style={{
+            flexBasis: 'auto',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}>
+            {city && (
+              <Typography variant="subtitle1">
+                Weather in{' '}
+                {city.replace(', United States', '').replace(', USA', '')}
+              </Typography>
+            )}
+            {!city && <Typography variant="subtitle1">Weather</Typography>}
+          </Grid>
+          <Grid item xs={4} style={{ minWidth: 105 }}>
+            <Grid container direction="row" spacing={1} justifyContent="flex-end">
+              <Grid item>
+                <WeatherDialogLauncher />
+              </Grid>
+              <Grid item>
+                <HidePop name="weather" />
+              </Grid>
+              <Grid item>
+                <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+              </Grid>
+              <Grid item>
+                <Dragger />
               </Grid>
             </Grid>
-          </>
-        </HeaderWrapper>
-        <WidgetBody />
-      </Dialog>
-    )
-  }
-  
+          </Grid>
+        </>
+      </HeaderWrapper>
+      <WidgetBody />
+    </Dialog>
+  )
 }
 
 export default wrapper(() => (

--- a/packages/widget-weather/src/Widget.tsx
+++ b/packages/widget-weather/src/Widget.tsx
@@ -33,19 +33,26 @@ let Today = React.memo(({ current, hourly, fullscreenMode } : TodayPropTypes ) =
       <Grid item xs={6} style={{ maxWidth: '100%' }}>
         <Grid
           container
-          direction="row"
+          direction={fullscreenMode ? 'column' : 'row'}
           spacing={2}
           alignItems="center"
           wrap="nowrap"
           justifyContent="space-evenly"
         >
-          <Grid item>
+          <Grid item sx={{
+            fontSize: {
+              xs: '75px',
+              sm: '150px',
+              md: '200px',
+              lg: '300px'
+            }
+          }}>
             <WeatherIcon
               name="owm"
               iconId={`${current.weather[0].id}`}
               flip="horizontal"
               rotate="90"
-              style={{ fontSize: fullscreenMode ? '300px' : '75px'}}
+              style={{ fontSize: fullscreenMode ? 'inherit' : '75px'}}
             />
           </Grid>
           <Grid item>

--- a/packages/widget-welcome/src/Widget.tsx
+++ b/packages/widget-welcome/src/Widget.tsx
@@ -127,43 +127,42 @@ let Welcome = () => {
         <WidgetBody />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <Grid item xs={1} style={{ maxWidth: '100%' }}>
-          <Box sx={{
-            borderBottom: '1px solid var(--vscode-editorGroup-border)',
-            padding: '8px 8px 4px',
-          }}>
-            <Grid
-              container
-              direction="row"
-              justifyContent="space-between"
-              alignItems="center"
-            >
-              <Grid item>
-                <Typography variant="subtitle1">Mailbox</Typography>
-              </Grid>
-              <Grid item>
-                <Grid container direction="row" spacing={1}>
-                  <Grid item>
-                    <PopMenu />
-                  </Grid>
-                  <Grid item>
-                    <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                  </Grid>
-                  <Grid item>
-                    <Dragger />
-                  </Grid>
+  }
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <Grid item xs={1} style={{ maxWidth: '100%' }}>
+        <Box sx={{
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
+          padding: '8px 8px 4px',
+        }}>
+          <Grid
+            container
+            direction="row"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <Grid item>
+              <Typography variant="subtitle1">Mailbox</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1}>
+                <Grid item>
+                  <PopMenu />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Box>
-        </Grid>
-        <WidgetBody />
-      </Dialog>
-    )
-  }
+          </Grid>
+        </Box>
+      </Grid>
+      <WidgetBody />
+    </Dialog>
+  )
 }
 
 const Widget = () => (

--- a/packages/widget-welcome/src/Widget.tsx
+++ b/packages/widget-welcome/src/Widget.tsx
@@ -1,122 +1,169 @@
-import React, { useContext } from 'react'
-import { Box, Grid, Link, Typography } from '@mui/material'
+import React, { useContext, useState } from 'react'
+import { Box, Dialog, Grid, Link, Typography } from '@mui/material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons/faDiscord'
 
-import wrapper, { Dragger } from '@vscode-marquee/widget'
+import wrapper, { Dragger, ToggleFullScreen } from '@vscode-marquee/widget'
 import { NetworkError } from '@vscode-marquee/utils'
 
 import TrickContext, { TrickProvider } from './Context'
 import TrickContent from './components/TrickContent'
 import PopMenu from './components/Pop'
 
-let Welcome = () => {
+const WidgetBody = () => {
   const { error } = useContext(TrickContext)
-
   const link = 'https://discord.gg/BQm8zRCBUY'
-
   return (
-    <>
-      <Grid item xs={1} style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        {error && (
           <Grid
-            container
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
+            item
+            xs
+            style={{
+              overflow: 'auto',
+              height: '100%',
+              width: '100%',
+              padding: '24px',
+            }}
           >
-            <Grid item>
-              <Typography variant="subtitle1">Mailbox</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1}>
-                <Grid item>
-                  <PopMenu />
+            <NetworkError message={error.message} />
+          </Grid>
+        )}
+        {!error && (
+          <Grid
+            item
+            xs
+            style={{
+              overflow: 'auto',
+              paddingTop: '16px',
+              paddingRight: '16px',
+              paddingLeft: '16px',
+              paddingBottom: '8px',
+            }}
+          >
+            <Grid
+              container
+              style={{
+                height: '100%',
+                width: '100%',
+              }}
+              direction="column"
+              wrap="nowrap"
+            >
+              <Grid item xs={1} style={{ maxWidth: '100%' }}>
+                <Grid
+                  container
+                  justifyContent="flex-end"
+                  alignItems="center"
+                  style={{ height: '100%', padding: '8px' }}
+                >
+                  <Grid item>
+                    <Typography variant="caption">
+                      <Link
+                        component="a"
+                        href={link}
+                        target="_blank"
+                        underline="hover">
+                        Join Discord &nbsp;
+                        <FontAwesomeIcon icon={faDiscord} />
+                      </Link>
+                    </Typography>
+                  </Grid>
                 </Grid>
-                <Grid item>
-                  <Dragger />
-                </Grid>
+              </Grid>
+              <Grid item xs={11} style={{ maxWidth: '100%' }}>
+                <TrickContent />
               </Grid>
             </Grid>
           </Grid>
-        </Box>
+        )}
       </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          {error && (
+    </Grid>
+  )
+}
+
+let Welcome = () => {
+  const [fullscreenMode, setFullscreenMode] = useState(false)
+  
+  if(!fullscreenMode){
+    return (
+      <>
+        <Grid item xs={1} style={{ maxWidth: '100%' }}>
+          <Box sx={{
+            borderBottom: '1px solid var(--vscode-editorGroup-border)',
+            padding: '8px 8px 4px',
+          }}>
             <Grid
-              item
-              xs
-              style={{
-                overflow: 'auto',
-                height: '100%',
-                width: '100%',
-                padding: '24px',
-              }}
+              container
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
             >
-              <NetworkError message={error.message} />
-            </Grid>
-          )}
-          {!error && (
-            <Grid
-              item
-              xs
-              style={{
-                overflow: 'auto',
-                paddingTop: '16px',
-                paddingRight: '16px',
-                paddingLeft: '16px',
-                paddingBottom: '8px',
-              }}
-            >
-              <Grid
-                container
-                style={{
-                  height: '100%',
-                  width: '100%',
-                }}
-                direction="column"
-                wrap="nowrap"
-              >
-                <Grid item xs={1} style={{ maxWidth: '100%' }}>
-                  <Grid
-                    container
-                    justifyContent="flex-end"
-                    alignItems="center"
-                    style={{ height: '100%', padding: '8px' }}
-                  >
-                    <Grid item>
-                      <Typography variant="caption">
-                        <Link
-                          component="a"
-                          href={link}
-                          target="_blank"
-                          underline="hover">
-                          Join Discord &nbsp;
-                          <FontAwesomeIcon icon={faDiscord} />
-                        </Link>
-                      </Typography>
-                    </Grid>
+              <Grid item>
+                <Typography variant="subtitle1">Mailbox</Typography>
+              </Grid>
+              <Grid item>
+                <Grid container direction="row" spacing={1}>
+                  <Grid item>
+                    <PopMenu />
                   </Grid>
-                </Grid>
-                <Grid item xs={11} style={{ maxWidth: '100%' }}>
-                  <TrickContent />
+                  <Grid item>
+                    <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                  </Grid>
+                  <Grid item>
+                    <Dragger />
+                  </Grid>
                 </Grid>
               </Grid>
             </Grid>
-          )}
+          </Box>
         </Grid>
-      </Grid>
-    </>
-  )
+        <WidgetBody />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <Grid item xs={1} style={{ maxWidth: '100%' }}>
+          <Box sx={{
+            borderBottom: '1px solid var(--vscode-editorGroup-border)',
+            padding: '8px 8px 4px',
+          }}>
+            <Grid
+              container
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+            >
+              <Grid item>
+                <Typography variant="subtitle1">Mailbox</Typography>
+              </Grid>
+              <Grid item>
+                <Grid container direction="row" spacing={1}>
+                  <Grid item>
+                    <PopMenu />
+                  </Grid>
+                  <Grid item>
+                    <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                  </Grid>
+                  <Grid item>
+                    <Dragger />
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Box>
+        </Grid>
+        <WidgetBody />
+      </Dialog>
+    )
+  }
 }
 
 const Widget = () => (

--- a/packages/widget/src/HeaderWrapper.tsx
+++ b/packages/widget/src/HeaderWrapper.tsx
@@ -1,0 +1,28 @@
+import React, { ReactChild } from 'react'
+import { Box, Grid } from '@mui/material'
+
+let HeaderWrapper = ({ children }: { children: ReactChild }) => {
+  return (
+    <Grid item style={{ maxWidth: '100%' }}>
+      <Box
+        sx={{
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
+          padding: '8px 8px 4px'
+        }}
+      >
+        <Grid
+          container
+          direction="row"
+          wrap="nowrap"
+          alignContent="stretch"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          {children}
+        </Grid>
+      </Box>
+    </Grid>
+  )
+}
+
+export default HeaderWrapper

--- a/packages/widget/src/ThirdPartyWidget.tsx
+++ b/packages/widget/src/ThirdPartyWidget.tsx
@@ -67,45 +67,44 @@ const ThirdPartyWidget = ({ name, label }: Props) => {
         <WidgetBody name={name} />
       </>
     )
-  } else {
-    return (
-      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
-        <Grid item xs={1} style={{ maxWidth: '100%' }}>
-          <Box sx={{
-            borderBottom: '1px solid var(--vscode-editorGroup-border)',
-            padding: '8px 8px 4px',
-          }}>
-            <Grid
-              container
-              direction="row"
-              wrap="nowrap"
-              alignItems="stretch"
-              alignContent="stretch"
-              justifyContent="space-between"
-            >
-              <Grid item>
-                <Typography variant="subtitle1">{label}</Typography>
-              </Grid>
-              <Grid item>
-                <Grid container direction="row" spacing={1}>
-                  <Grid item>
-                    <HidePop name={name} />
-                  </Grid>
-                  <Grid item>
-                    <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
-                  </Grid>
-                  <Grid item>
-                    <Dragger />
-                  </Grid>
+  }
+  return (
+    <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+      <Grid item xs={1} style={{ maxWidth: '100%' }}>
+        <Box sx={{
+          borderBottom: '1px solid var(--vscode-editorGroup-border)',
+          padding: '8px 8px 4px',
+        }}>
+          <Grid
+            container
+            direction="row"
+            wrap="nowrap"
+            alignItems="stretch"
+            alignContent="stretch"
+            justifyContent="space-between"
+          >
+            <Grid item>
+              <Typography variant="subtitle1">{label}</Typography>
+            </Grid>
+            <Grid item>
+              <Grid container direction="row" spacing={1}>
+                <Grid item>
+                  <HidePop name={name} />
+                </Grid>
+                <Grid item>
+                  <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                </Grid>
+                <Grid item>
+                  <Dragger />
                 </Grid>
               </Grid>
             </Grid>
-          </Box>
-        </Grid>
-        <WidgetBody name={name} />
-      </Dialog>
-    )
-  }
+          </Grid>
+        </Box>
+      </Grid>
+      <WidgetBody name={name} />
+    </Dialog>
+  )
 }
 
 export default ThirdPartyWidget

--- a/packages/widget/src/ThirdPartyWidget.tsx
+++ b/packages/widget/src/ThirdPartyWidget.tsx
@@ -1,62 +1,111 @@
-import React from 'react'
-import { Box, Grid, Typography } from '@mui/material'
+import React, { useState } from 'react'
+import { Box, Dialog, Grid, Typography } from '@mui/material'
 
 import HidePop from './HidePop'
 import Dragger from './Dragger'
+import ToggleFullScreen from './ToggleFullScreen'
 
 interface Props {
   name: string;
   label: string;
 }
+const WidgetBody = ({ name } : { name:string }) => {
+  const WidgetTag = name
+  return(
+    <Grid item xs>
+      <Grid
+        container
+        wrap="nowrap"
+        direction="column"
+        style={{ height: '100%' }}
+      >
+        <Grid item xs style={{ overflow: 'auto' }}>
+          <WidgetTag />
+        </Grid>
+      </Grid>
+    </Grid>
+  )
+}
 
 const ThirdPartyWidget = ({ name, label }: Props) => {
-  const WidgetTag = name
-
-  return (
-    <>
-      <Grid item xs={1} style={{ maxWidth: '100%' }}>
-        <Box sx={{
-          borderBottom: '1px solid var(--vscode-editorGroup-border)',
-          padding: '8px 8px 4px',
-        }}>
-          <Grid
-            container
-            direction="row"
-            wrap="nowrap"
-            alignItems="stretch"
-            alignContent="stretch"
-            justifyContent="space-between"
-          >
-            <Grid item>
-              <Typography variant="subtitle1">{label}</Typography>
-            </Grid>
-            <Grid item>
-              <Grid container direction="row" spacing={1}>
-                <Grid item>
-                  <HidePop name={name} />
-                </Grid>
-                <Grid item>
-                  <Dragger />
+  const [fullscreenMode, setFullscreenMode] = useState(false)
+  if(!fullscreenMode){
+    return (
+      <>
+        <Grid item xs={1} style={{ maxWidth: '100%' }}>
+          <Box sx={{
+            borderBottom: '1px solid var(--vscode-editorGroup-border)',
+            padding: '8px 8px 4px',
+          }}>
+            <Grid
+              container
+              direction="row"
+              wrap="nowrap"
+              alignItems="stretch"
+              alignContent="stretch"
+              justifyContent="space-between"
+            >
+              <Grid item>
+                <Typography variant="subtitle1">{label}</Typography>
+              </Grid>
+              <Grid item>
+                <Grid container direction="row" spacing={1}>
+                  <Grid item>
+                    <HidePop name={name} />
+                  </Grid>
+                  <Grid item>
+                    <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                  </Grid>
+                  <Grid item>
+                    <Dragger />
+                  </Grid>
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
-        </Box>
-      </Grid>
-      <Grid item xs>
-        <Grid
-          container
-          wrap="nowrap"
-          direction="column"
-          style={{ height: '100%' }}
-        >
-          <Grid item xs style={{ overflow: 'auto' }}>
-            <WidgetTag />
-          </Grid>
+          </Box>
         </Grid>
-      </Grid>
-    </>
-  )
+        <WidgetBody name={name} />
+      </>
+    )
+  } else {
+    return (
+      <Dialog fullScreen open={fullscreenMode} onClose={() => setFullscreenMode(false)}>
+        <Grid item xs={1} style={{ maxWidth: '100%' }}>
+          <Box sx={{
+            borderBottom: '1px solid var(--vscode-editorGroup-border)',
+            padding: '8px 8px 4px',
+          }}>
+            <Grid
+              container
+              direction="row"
+              wrap="nowrap"
+              alignItems="stretch"
+              alignContent="stretch"
+              justifyContent="space-between"
+            >
+              <Grid item>
+                <Typography variant="subtitle1">{label}</Typography>
+              </Grid>
+              <Grid item>
+                <Grid container direction="row" spacing={1}>
+                  <Grid item>
+                    <HidePop name={name} />
+                  </Grid>
+                  <Grid item>
+                    <ToggleFullScreen toggleFullScreen={setFullscreenMode} isFullScreenMode={fullscreenMode} />
+                  </Grid>
+                  <Grid item>
+                    <Dragger />
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Box>
+        </Grid>
+        <WidgetBody name={name} />
+      </Dialog>
+    )
+  }
 }
 
 export default ThirdPartyWidget

--- a/packages/widget/src/ToggleFullScreen.tsx
+++ b/packages/widget/src/ToggleFullScreen.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { IconButton } from '@mui/material'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand'
+import { faClose } from '@fortawesome/free-solid-svg-icons'
+
+interface ToggleFSProps {
+  isFullScreenMode: boolean, 
+  toggleFullScreen: React.Dispatch<React.SetStateAction<boolean>>
+}
+let ToggleFullScreen = ({ isFullScreenMode, toggleFullScreen } : ToggleFSProps) => {
+  return (
+    <IconButton focusRipple={false} onClick={() => toggleFullScreen(!isFullScreenMode)}>
+      {!isFullScreenMode && <FontAwesomeIcon icon={faExpand} fontSize='small' />}
+      {isFullScreenMode && <FontAwesomeIcon icon={faClose} fontSize='small' />}
+    </IconButton>
+  )
+}
+
+export default ToggleFullScreen

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -4,6 +4,8 @@ import WidgetWrapper from './WidgetWrapper'
 import ThirdPartyWidget from './ThirdPartyWidget'
 import HideWidgetContent from './HideWidgetContent'
 import SplitButton from './SplitButton'
+import ToggleFullScreen from './ToggleFullScreen'
+import HeaderWrapper from './HeaderWrapper'
 
 export default WidgetWrapper
-export { Dragger, HidePop, ThirdPartyWidget, HideWidgetContent, SplitButton }
+export { Dragger, HidePop, ThirdPartyWidget, HideWidgetContent, SplitButton, ToggleFullScreen, HeaderWrapper}


### PR DESCRIPTION
… can take the whole view of the extension space

For issue - https://github.com/stateful/vscode-marquee/issues/129

Had to go onto each `Widget` file and add a conditional whether to show the extension as a fullscreen dialog or not. Did try to keep things `"DRY"`, but had to use a conditional render to differentiate between a `mui grid view` (how it should look by default) and a `dialog fullscreen`. 