### PR TITLE
Don't retain tricks in prevTricks until first propagation

### DIFF
--- a/packages/widget-welcome/tests/extension.test.ts
+++ b/packages/widget-welcome/tests/extension.test.ts
@@ -29,7 +29,7 @@ test('should return expected interface', async () => {
     emit: jest.fn(),
     broadcast: jest.fn(),
     listen: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
-    whenReady: jest.fn(),
+    whenReady: jest.fn().mockReturnValue({ then: jest.fn().mockImplementation(() => Promise.resolve()) }),
     removeAllListeners: jest.fn()
   }
   const context = { globalState: new Map() }

--- a/packages/widget-welcome/tests/extension.test.ts
+++ b/packages/widget-welcome/tests/extension.test.ts
@@ -29,7 +29,7 @@ test('should return expected interface', async () => {
     emit: jest.fn(),
     broadcast: jest.fn(),
     listen: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
-    whenReady: jest.fn().mockReturnValue({ then: jest.fn().mockImplementation(() => Promise.resolve()) }),
+    whenReady: jest.fn().mockReturnValue(Promise.resolve()),
     removeAllListeners: jest.fn()
   }
   const context = { globalState: new Map() }

--- a/packages/widget-welcome/tests/extension.test.ts
+++ b/packages/widget-welcome/tests/extension.test.ts
@@ -29,6 +29,7 @@ test('should return expected interface', async () => {
     emit: jest.fn(),
     broadcast: jest.fn(),
     listen: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    whenReady: jest.fn(),
     removeAllListeners: jest.fn()
   }
   const context = { globalState: new Map() }


### PR DESCRIPTION
If auto-launch is disabled, new tricks will get swallowed otherwise. This fix will work for both scenarios.