### PR TITLE
[🐛 Bug]: syncing state is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ This extension contributes the following settings:
 * `marquee.configuration.proxy` (type: `string`, default: `""`): URL to proxy (e.g. `https://username:password@domain.tld:port`). __Note:__ This only has an effect on widgets that gather data from the extension host (e.g. Welcome Widget).
 * `marquee.configuration.fontSize` (type: `number`, default: `5`): Font Size of Widgets (`0` very small / `10` very large).
 * `marquee.configuration.colorScheme` (type: `object`, default: `{}`): The color scheme applied to the Marquee Webview (default is based on the current VSCode color scheme).
-* `marquee.configuration.name` (type: `string`, default: `name here...`): Your name so Marquee can greet you!
-* `marquee.configuration.background` (type: `string`, default: `1`): Homescreen background image (currently only numbers between 1-10 are available, we will add support for Unsplash images soon).
+* `marquee.gui.name` (type: `string`, default: `name here...`): Your name so Marquee can greet you!
+* `marquee.gui.background` (type: `string`, default: `1`): Homescreen background image (currently only numbers between 1-10 are available, we will add support for Unsplash images soon).
 * `marquee.configuration.modes` (type: `object`): Configuration of your widget location and display.
 * `marquee.configuration.launchOnStartup` (type: `boolean`, default: `true`): Open Marquee when VS Code starts up.
 * `marquee.configuration.workspaceLaunch` (type: `boolean`, default: `false`): Only auto-launch Marquee in Workspaces.

--- a/package.json
+++ b/package.json
@@ -435,13 +435,13 @@
             "additionalProperties": false,
             "description": "The color scheme applied to the Marquee Webview (default is based on the current VSCode color scheme)"
           },
-          "marquee.configuration.name": {
+          "marquee.gui.name": {
             "type": "string",
             "scope": "window",
             "default": "name here...",
             "markdownDescription": "Your name so Marquee can greet you!"
           },
-          "marquee.configuration.background": {
+          "marquee.gui.background": {
             "type": "string",
             "scope": "window",
             "default": "1",

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -11,6 +11,6 @@ export const DEFAULT_STATE: State = {
 }
 
 export const DEFAULT_CONFIGURATION: Configuration = {
-  background: defaultConfigurations['marquee.configuration.background'].default,
-  name: defaultConfigurations['marquee.configuration.name'].default
+  background: defaultConfigurations['marquee.gui.background'].default,
+  name: defaultConfigurations['marquee.gui.name'].default
 }

--- a/packages/utils/tests/__snapshots__/extension.test.ts.snap
+++ b/packages/utils/tests/__snapshots__/extension.test.ts.snap
@@ -31,6 +31,8 @@ Object {
 }
 `;
 
+exports[`setKeysForSync 1`] = `"A widget with key bar is already synced"`;
+
 exports[`should apply old configuration if available 1`] = `
 Object {
   "defaultConfig": "old config",

--- a/packages/utils/tests/extension.test.ts
+++ b/packages/utils/tests/extension.test.ts
@@ -1,5 +1,5 @@
 import vscode from 'vscode'
-import ExtensionManager, { activate, getExtProps } from '../src/extension'
+import ExtensionManager, { activate, getExtProps, setKeysForSync, widgetsToSync } from '../src/extension'
 
 const context = {
   globalState: {
@@ -13,6 +13,10 @@ jest.mock('os', () => ({
   platform: () => 'some platform',
   release: () => 'some release'
 }))
+
+beforeEach(() => {
+  widgetsToSync.clear()
+})
 
 test('generate proper default state and configuration', () => {
   const manager = new ExtensionManager(
@@ -360,4 +364,18 @@ test('should not propagate telemetry data if not opted in', () => {
   (vscode.workspace.getConfiguration as jest.Mock)
     .mockReturnValueOnce({ get: jest.fn().mockReturnValue(false) })
   expect(getExtProps()).toEqual({})
+})
+
+test('setKeysForSync', () => {
+  const context: any = {
+    globalState: { setKeysForSync: jest.fn() }
+  }
+  setKeysForSync(context, 'foo')
+  expect(context.globalState.setKeysForSync).toBeCalledWith(['foo'])
+  setKeysForSync(context, 'bar')
+  expect(context.globalState.setKeysForSync).toBeCalledWith(['foo', 'bar'])
+  setKeysForSync(context, 'loo')
+  expect(context.globalState.setKeysForSync).toBeCalledWith(['foo', 'bar', 'loo'])
+
+  expect(() => setKeysForSync(context, 'bar')).toThrowErrorMatchingSnapshot()
 })


### PR DESCRIPTION
### VSCode Environment

all

### Marquee Version

all

### Workspace Type

Local Workspace

### What happened?

Currently every widget with an `ExtensionManager` calls:

```ts
this._context.globalState.setKeysForSync(Object.keys(this._defaultState))
```

when it gets initiated. So this happens multiple times for multiple widgets. The problem with that is that it should be called once for all keys that should be synced. Calling it with a different array of keys will replace keys already called by a different widget.

### What is your expected behavior?

Collect all keys that are supposed to be synced and call the method then.

### Relevant Log Output

n/a

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues