### PR TITLE
Refine sentry

### DIFF
--- a/packages/gui/src/sentry.ts
+++ b/packages/gui/src/sentry.ts
@@ -11,7 +11,6 @@ function init (userID?: string) {
   Sentry.init({
     dsn: SENTRY_DNS,
     beforeSend (event){
-      console.log(event)
       if(event.environment === 'development'){
         return null
       }

--- a/packages/gui/src/sentry.ts
+++ b/packages/gui/src/sentry.ts
@@ -10,6 +10,15 @@ function init (userID?: string) {
 
   Sentry.init({
     dsn: SENTRY_DNS,
+    beforeSend (event){
+      if(event.environment === 'development'){
+        return null
+      }
+      if(event.platform === 'javascript'){
+        event.fingerprint = ['webview']
+      }
+      return event
+    },
     integrations: [
       new Integrations.BrowserTracing(),
       new CaptureConsole({ levels: ['error'] }),

--- a/packages/gui/src/sentry.ts
+++ b/packages/gui/src/sentry.ts
@@ -5,8 +5,9 @@ import { CaptureConsole } from '@sentry/integrations'
 import { SENTRY_DNS } from './constants'
 
 function init (userID?: string) {
-  const env =
-    process.env.NODE_ENV === 'development' ? 'development' : 'production'
+  const env = process.env.NODE_ENV === 'development' 
+    ? 'development'
+    : 'production'
 
   Sentry.init({
     dsn: SENTRY_DNS,

--- a/packages/gui/src/sentry.ts
+++ b/packages/gui/src/sentry.ts
@@ -11,11 +11,9 @@ function init (userID?: string) {
   Sentry.init({
     dsn: SENTRY_DNS,
     beforeSend (event){
+      console.log(event)
       if(event.environment === 'development'){
         return null
-      }
-      if(event.platform === 'javascript'){
-        event.fingerprint = ['webview']
       }
       return event
     },
@@ -25,6 +23,10 @@ function init (userID?: string) {
     ],
     environment: env,
     tracesSampleRate: 1,
+  })
+
+  Sentry.configureScope(function (scope) {
+    scope.setTag('occurred', 'webview')
   })
 
   if (userID) {

--- a/packages/gui/tests/__snapshots__/sentry.test.ts.snap
+++ b/packages/gui/tests/__snapshots__/sentry.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`init 1`] = `
 Object {
+  "beforeSend": [Function],
   "dsn": "SENTRY_DNS",
   "environment": "production",
   "integrations": Array [

--- a/packages/gui/tests/sentry.test.ts
+++ b/packages/gui/tests/sentry.test.ts
@@ -15,11 +15,11 @@ beforeEach(() => {
 test('init', () => {
   SentryModule.init()
   expect((Sentry.init as jest.Mock).mock.calls[0][0]).toMatchSnapshot()
-  expect(Sentry.configureScope).toBeCalledTimes(0)
+  expect(Sentry.configureScope).toBeCalledTimes(1)
   expect(Integrations.BrowserTracing).toBeCalledTimes(1)
   expect(CaptureConsole).toBeCalledTimes(1)
   SentryModule.init('foobar')
-  expect(Sentry.configureScope).toBeCalledTimes(1)
+  expect(Sentry.configureScope).toBeCalledTimes(3)
 })
 
 test('setUserID', () => {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,6 +6,8 @@
   "main": "./build",
   "types": "./build/index.d.ts",
   "dependencies": {
+    "@sentry/node": "^7.3.0",
+    "@sentry/tracing": "^7.3.0",
     "@types/lodash.pick": "^4.4.6",
     "@types/object-hash": "^2.2.1",
     "@types/uuid": "^8.3.4",

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -293,14 +293,15 @@ export function activate (
     beforeSend (event){
       if(event.environment === 'development'){
         return null
-      }
-      if(event.platform === 'node'){
-        event.fingerprint = ['extension host']
-      }
+      } 
       return event
     },
     environment: env,
     tracesSampleRate: 1,
+  })
+
+  Sentry.configureScope(function (scope) {
+    scope.setTag('occurred', 'extension-host')
   })
 
   /**

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -5,10 +5,12 @@ import hash from 'object-hash'
 import { v4 as uuidv4, v5 as uuidv5 } from 'uuid'
 import { Client } from 'tangle'
 import { EventEmitter } from 'events'
+import * as Sentry from '@sentry/node'
 
 import { DEFAULT_CONFIGURATION, DEFAULT_STATE, DEPRECATED_GLOBAL_STORE_KEY, EXTENSION_ID, pkg } from './constants'
 import { WorkspaceType } from './types'
 import type { Configuration, State, Workspace } from './types'
+import { SENTRY_DNS } from './utils'
 
 const NAMESPACE = '144fb8a8-7dbf-4241-8795-0dc12b8e2fb6'
 const CONFIGURATION_TARGET = vscode.ConfigurationTarget.Global
@@ -280,6 +282,26 @@ export function activate (
   if (oldGlobalStore.bg) {
     stateManager.updateConfiguration('background', oldGlobalStore.bg)
   }
+
+  /**
+   * extension host has access to events
+   */
+  const env =
+   process.env.NODE_ENV === 'development' ? 'development' : 'production'
+  Sentry.init({
+    dsn: SENTRY_DNS,
+    beforeSend (event){
+      if(event.environment === 'development'){
+        return null
+      }
+      if(event.platform === 'node'){
+        event.fingerprint = ['extension host']
+      }
+      return event
+    },
+    environment: env,
+    tracesSampleRate: 1,
+  })
 
   /**
    * set global state to true if we don't have a workspace

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -284,10 +284,12 @@ export function activate (
   }
 
   /**
-   * extension host has access to events
+   * extension host has access to sentry events
    */
-  const env =
-   process.env.NODE_ENV === 'development' ? 'development' : 'production'
+  const env = process.env.NODE_ENV === 'development' 
+    ? 'development'
+    : 'production'
+
   Sentry.init({
     dsn: SENTRY_DNS,
     beforeSend (event){

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -16,3 +16,5 @@ export const getVSColor = () => {
     a: 0.8,
   } as RGBA
 }
+
+export const SENTRY_DNS = 'https://6e86226331e84bd9885554fdac788ce7@o481102.ingest.sentry.io/5543775'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,6 +1637,16 @@
     "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
+"@sentry/core@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.3.0.tgz#5e7c96efca254401dfc0e92f27cc9d4105bb0d52"
+  integrity sha512-EvuWVlYm0F0+BtIEmQiCL31Fw0cfKSwUTmxc99wvouaabpHBr2zCJHRxaXOWzxS705bYBJEQiFDTIHfoOQZMzA==
+  dependencies:
+    "@sentry/hub" "7.3.0"
+    "@sentry/types" "7.3.0"
+    "@sentry/utils" "7.3.0"
+    tslib "^1.9.3"
+
 "@sentry/hub@6.19.7":
   version "6.19.7"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.7.tgz#58ad7776bbd31e9596a8ec46365b45cd8b9cfd11"
@@ -1644,6 +1654,15 @@
   dependencies:
     "@sentry/types" "6.19.7"
     "@sentry/utils" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/hub@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.3.0.tgz#ecb251b1191b503a7516e4f50503f096ac63e1c5"
+  integrity sha512-0GtTaWf/hoAMoIFY7Ke6eozIbG3FdIPM364sER4SxUQVSklp6AORrV6p82IgWPROK6aj83cPk9Bszgi6RiF/BA==
+  dependencies:
+    "@sentry/types" "7.3.0"
+    "@sentry/utils" "7.3.0"
     tslib "^1.9.3"
 
 "@sentry/integrations@^6.19.3":
@@ -1663,6 +1682,20 @@
   dependencies:
     "@sentry/hub" "6.19.7"
     "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/node@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.3.0.tgz#93e54161b83e3cd76176600df9d2b0972d0c6cdf"
+  integrity sha512-hPqLQMdpL9MeirtKDCgy0ekptWh58CCUhvcoQ2bYstVBsyMMTNTbiQqF/ClzanrScQ5CEuGWnCbKxrFN/S6cQg==
+  dependencies:
+    "@sentry/core" "7.3.0"
+    "@sentry/hub" "7.3.0"
+    "@sentry/types" "7.3.0"
+    "@sentry/utils" "7.3.0"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
     tslib "^1.9.3"
 
 "@sentry/react@^6.19.3":
@@ -1688,10 +1721,25 @@
     "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
+"@sentry/tracing@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-7.3.0.tgz#c3ab22eeec6c3f80ca1a4acee86c537cc3517cc7"
+  integrity sha512-A+mLEH8jtLkhfyw81EZA1XgI96jh9TIwH9EST3hdfSPgdZQf0A5sV8oVVh/d9Hw7NVb65Va5KhAZDNhcx5QxUA==
+  dependencies:
+    "@sentry/hub" "7.3.0"
+    "@sentry/types" "7.3.0"
+    "@sentry/utils" "7.3.0"
+    tslib "^1.9.3"
+
 "@sentry/types@6.19.7":
   version "6.19.7"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
   integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
+
+"@sentry/types@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.3.0.tgz#eb3b9dc0bd26503eab4a5a205f0b3889b2bf7c4f"
+  integrity sha512-cGkHdh9+uvbFTj65TjWcXuhe6vQiMY+U+N2GE5xCfmZT9hwuouCASViNsbJMpZqvCg+Yi0fasQLZ71rujiRNOA==
 
 "@sentry/utils@6.19.7":
   version "6.19.7"
@@ -1699,6 +1747,14 @@
   integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
   dependencies:
     "@sentry/types" "6.19.7"
+    tslib "^1.9.3"
+
+"@sentry/utils@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.3.0.tgz#d2970b26a75d30659dcc54ea632ba62fe9ded478"
+  integrity sha512-xUP8TBf2p/c6CN8eFQ7Y+xk0IFrJXsph5ScozqNl/2l/Xs8hd2EiYETqgUklphoYD4J2RxvPwMyqBL15QN6wNg==
+  dependencies:
+    "@sentry/types" "7.3.0"
     tslib "^1.9.3"
 
 "@sinclair/typebox@^0.23.3":
@@ -3934,6 +3990,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0,
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 cookies@~0.8.0:
   version "0.8.0"
@@ -7300,6 +7361,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
 
 lz-string@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
for - https://github.com/stateful/vscode-marquee/issues/141

events with `environment = 'development' `will not be sent out to Sentry.


Also Extension Host errors will have tags with a runtime of `node` and their version. On search we can filter based on the tags set - `occured:extension-host` and `occured:webview`

<img width="1245" alt="Screen Shot 2022-06-27 at 3 58 26 PM" src="https://user-images.githubusercontent.com/63378463/176051236-2ca9bfc2-4c9c-4a7d-9d5b-29faa7e1797a.png">

<img width="1247" alt="Screen Shot 2022-06-27 at 3 58 12 PM" src="https://user-images.githubusercontent.com/63378463/176051239-cf0b1c4c-dff6-4065-85d4-8d5e522016fc.png">

