### PR TITLE
[💡 Feature]: Move pre-release (edge) to prod backend

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,7 +5,7 @@ import { Configuration, DefinePlugin, ProvidePlugin } from "webpack";
 import CopyPlugin from "copy-webpack-plugin";
 
 const pkg = fs.readFileSync(`${__dirname}/package.json`).toString('utf8');
-const isDevelopment = process.env.NODE_ENV === "development";
+const isDevelopment = !Boolean(process.env.NODE_ENV)
 
 const extensionConfig: Configuration = {
   target: "node",


### PR DESCRIPTION
### Is your feature request related to a problem?

Sort of. Dev is for dev versus staging/prod. It's hard to test drive release candidates without the proper backend.

### Describe the solution you'd like.

Use the production backend until there's perhaps a dedicated staging backend that replicates some of the prod backends data.

### Describe alternatives you've considered.

I have considered leaving it as it is. However, I feel strongly that pre-release is not development and if we have to choose between dev vs prod, it's closer to prod.

### Additional context

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct