### PR TITLE
Allow to sort projects by most and recently visited

### DIFF
--- a/packages/widget-projects/src/Widget.tsx
+++ b/packages/widget-projects/src/Widget.tsx
@@ -17,7 +17,8 @@ declare const window: MarqueeWindow
 let Projects = ({ ToggleFullScreen }: MarqueeWidgetProps) => {
   const {
     notes, todos, snippets, workspaces, workspaceFilter,
-    workspaceSortOrder, openProjectInNewWindow, visitCount
+    workspaceSortOrder, openProjectInNewWindow, visitCount,
+    lastVisited
   } = useContext(WorkspaceContext)
 
   const totalLen = (wspid: string) => {
@@ -47,6 +48,8 @@ let Projects = ({ ToggleFullScreen }: MarqueeWidgetProps) => {
       return filteredProjects.sort((a, b) => totalLen(b.id) - totalLen(a.id))
     } else if (workspaceSortOrder === 'visits') {
       return filteredProjects.sort((a, b) => (visitCount[b.id] || 0) - (visitCount[a.id] || 0))
+    } else if (workspaceSortOrder === 'recent') {
+      return filteredProjects.sort((a, b) => (lastVisited[b.id] || 0) - (lastVisited[a.id] || 0))
     } else {
       return filteredProjects.sort((a, b) => a.name.localeCompare(b.name))
     }

--- a/packages/widget-projects/src/Widget.tsx
+++ b/packages/widget-projects/src/Widget.tsx
@@ -17,7 +17,7 @@ declare const window: MarqueeWindow
 let Projects = ({ ToggleFullScreen }: MarqueeWidgetProps) => {
   const {
     notes, todos, snippets, workspaces, workspaceFilter,
-    workspaceSortOrder, openProjectInNewWindow
+    workspaceSortOrder, openProjectInNewWindow, visitCount
   } = useContext(WorkspaceContext)
 
   const totalLen = (wspid: string) => {
@@ -45,10 +45,12 @@ let Projects = ({ ToggleFullScreen }: MarqueeWidgetProps) => {
     }
     if (workspaceSortOrder === 'usage') {
       return filteredProjects.sort((a, b) => totalLen(b.id) - totalLen(a.id))
+    } else if (workspaceSortOrder === 'visits') {
+      return filteredProjects.sort((a, b) => (visitCount[b.id] || 0) - (visitCount[a.id] || 0))
     } else {
       return filteredProjects.sort((a, b) => a.name.localeCompare(b.name))
     }
-  }, [workspaces, workspaceFilter, workspaceSortOrder])
+  }, [workspaces, workspaceFilter, workspaceSortOrder, visitCount])
 
   return (
     <>

--- a/packages/widget-projects/src/components/ItemPop.tsx
+++ b/packages/widget-projects/src/components/ItemPop.tsx
@@ -10,7 +10,7 @@ import WorkspaceContext from '../Context'
 declare const window: MarqueeWindow
 
 let TodoItemPop = ({ workspace }: { workspace: Workspace }) => {
-  const { openProjectInNewWindow, _removeWorkspace } = useContext(WorkspaceContext)
+  const { openProjectInNewWindow, _removeWorkspace, setLastVisited } = useContext(WorkspaceContext)
   const [anchorEl, setAnchorEl] = useState(null)
 
   const handleClick = useCallback((event) => {
@@ -59,6 +59,17 @@ let TodoItemPop = ({ workspace }: { workspace: Workspace }) => {
         </ListItem>
         <ListItem button onClick={(e) => {
           e.preventDefault()
+
+          /**
+           * mark workspace as last visited
+           */
+          if (window.activeWorkspace) {
+            setLastVisited(window.activeWorkspace.id)
+          }
+
+          /**
+           * open new workspace
+           */
           window.vscode.postMessage({
             west: { execCommands: [{
               command: 'vscode.openFolder',

--- a/packages/widget-projects/src/components/ItemPop.tsx
+++ b/packages/widget-projects/src/components/ItemPop.tsx
@@ -10,7 +10,7 @@ import WorkspaceContext from '../Context'
 declare const window: MarqueeWindow
 
 let TodoItemPop = ({ workspace }: { workspace: Workspace }) => {
-  const { openProjectInNewWindow, _removeWorkspace, setLastVisited } = useContext(WorkspaceContext)
+  const { openProjectInNewWindow, _removeWorkspace } = useContext(WorkspaceContext)
   const [anchorEl, setAnchorEl] = useState(null)
 
   const handleClick = useCallback((event) => {
@@ -59,24 +59,13 @@ let TodoItemPop = ({ workspace }: { workspace: Workspace }) => {
         </ListItem>
         <ListItem button onClick={(e) => {
           e.preventDefault()
-
-          /**
-           * mark workspace as last visited
-           */
-          if (window.activeWorkspace) {
-            setLastVisited(window.activeWorkspace.id)
-          }
-
-          /**
-           * open new workspace
-           */
           window.vscode.postMessage({
             west: { execCommands: [{
               command: 'vscode.openFolder',
               args: [workspace.path],
               options: { forceNewWindow: openProjectInNewWindow }
-            }],
-            }})
+            }]}
+          })
         }}>
           <ListItemText
             primary={

--- a/packages/widget-projects/src/components/ListItem.tsx
+++ b/packages/widget-projects/src/components/ListItem.tsx
@@ -49,8 +49,9 @@ interface ProjectListItemProps {
 let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
   const { themeColor } = useContext(GlobalContext)
 
-  const { openProjectInNewWindow, notes, todos, snippets, lastVisited, setLastVisited } = useContext(WorkspaceContext)
+  const { openProjectInNewWindow, notes, todos, snippets, lastVisited } = useContext(WorkspaceContext)
 
+  const isLastVisitedWorkspace = Math.max(...Object.values(lastVisited)) === lastVisited[workspace.id]
   let todoCount = useMemo(() => {
     return todos.filter((todo: any) => todo.workspaceId === workspace.id && !todo.archived)
   }, [workspace, todos])
@@ -87,13 +88,6 @@ let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
       target.parentElement.getAttribute('role') === 'presentation'
     ) {
       return
-    }
-
-    /**
-     * mark workspace as last visited
-     */
-    if (window.activeWorkspace) {
-      setLastVisited(window.activeWorkspace.id)
     }
 
     /**
@@ -142,7 +136,7 @@ let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
               <Grid item>
                 <Typography variant="body2">
                   {workspace.name}
-                  {workspace.id === lastVisited && (
+                  {isLastVisitedWorkspace && (
                     <i style={{ paddingLeft: 5 }}>(last visited)</i>
                   )}
                 </Typography>

--- a/packages/widget-projects/src/components/ListItem.tsx
+++ b/packages/widget-projects/src/components/ListItem.tsx
@@ -191,7 +191,7 @@ let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
             </Grid>
           }
           secondary={
-            <Typography variant="caption" noWrap style={{ display: 'block' }}>
+            <Typography variant="caption" data-testid="projectPath" noWrap style={{ display: 'block' }}>
               {workspace.path}
             </Typography>
           }

--- a/packages/widget-projects/src/components/ListItem.tsx
+++ b/packages/widget-projects/src/components/ListItem.tsx
@@ -49,7 +49,7 @@ interface ProjectListItemProps {
 let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
   const { themeColor } = useContext(GlobalContext)
 
-  const { openProjectInNewWindow, notes, todos, snippets } = useContext(WorkspaceContext)
+  const { openProjectInNewWindow, notes, todos, snippets, lastVisited, setLastVisited } = useContext(WorkspaceContext)
 
   let todoCount = useMemo(() => {
     return todos.filter((todo: any) => todo.workspaceId === workspace.id && !todo.archived)
@@ -89,6 +89,16 @@ let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
       return
     }
 
+    /**
+     * mark workspace as last visited
+     */
+    if (window.activeWorkspace) {
+      setLastVisited(window.activeWorkspace.id)
+    }
+
+    /**
+     * open new workspace
+     */
     window.vscode.postMessage({
       west: {
         execCommands: [
@@ -130,7 +140,12 @@ let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
               wrap="nowrap"
             >
               <Grid item>
-                <Typography variant="body2">{workspace.name}</Typography>
+                <Typography variant="body2">
+                  {workspace.name}
+                  {workspace.id === lastVisited && (
+                    <i style={{ paddingLeft: 5 }}>(last visited)</i>
+                  )}
+                </Typography>
               </Grid>
               <Grid item>
                 <Grid

--- a/packages/widget-projects/src/components/Pop.tsx
+++ b/packages/widget-projects/src/components/Pop.tsx
@@ -8,6 +8,7 @@ import ToggleButton from '@mui/material/ToggleButton'
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import SortByAlphaIcon from '@mui/icons-material/SortByAlpha'
 import SortIcon from '@mui/icons-material/Sort'
+import TourIcon from '@mui/icons-material/Tour'
 
 import WorkspaceContext from '../Context'
 import type { WorkspaceSortOrder } from '../types'
@@ -82,6 +83,16 @@ const SortOrder = React.memo(() => {
                 arrow
               >
                 <SortIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+
+            <ToggleButton value="visits">
+              <Tooltip
+                title="Sort by amount of visits to that workspace"
+                placement="top"
+                arrow
+              >
+                <TourIcon fontSize="small" />
               </Tooltip>
             </ToggleButton>
           </ToggleButtonGroup>

--- a/packages/widget-projects/src/components/Pop.tsx
+++ b/packages/widget-projects/src/components/Pop.tsx
@@ -9,6 +9,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import SortByAlphaIcon from '@mui/icons-material/SortByAlpha'
 import SortIcon from '@mui/icons-material/Sort'
 import TourIcon from '@mui/icons-material/Tour'
+import AccessTimeIcon from '@mui/icons-material/AccessTime'
 
 import WorkspaceContext from '../Context'
 import type { WorkspaceSortOrder } from '../types'
@@ -93,6 +94,17 @@ const SortOrder = React.memo(() => {
                 arrow
               >
                 <TourIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+
+
+            <ToggleButton value="recent">
+              <Tooltip
+                title="Sort by recent visited workspace"
+                placement="top"
+                arrow
+              >
+                <AccessTimeIcon fontSize="small" />
               </Tooltip>
             </ToggleButton>
           </ToggleButtonGroup>

--- a/packages/widget-projects/src/constants.ts
+++ b/packages/widget-projects/src/constants.ts
@@ -7,5 +7,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
 }
 
 export const DEFAULT_STATE: State = {
-  workspaces: []
+  workspaces: [],
+  lastVisited: null,
+  visitCount: {}
 }

--- a/packages/widget-projects/src/constants.ts
+++ b/packages/widget-projects/src/constants.ts
@@ -8,6 +8,6 @@ export const DEFAULT_CONFIGURATION: Configuration = {
 
 export const DEFAULT_STATE: State = {
   workspaces: [],
-  lastVisited: null,
+  lastVisited: {},
   visitCount: {}
 }

--- a/packages/widget-projects/src/extension.ts
+++ b/packages/widget-projects/src/extension.ts
@@ -19,7 +19,7 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
      * add new workspace to list
      */
     if (
-    /**
+      /**
        * the current workspace can be detected
        */
       aws &&
@@ -41,6 +41,31 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
       typeof vscode.env.remoteName === 'undefined'
     ) {
       this.updateState('workspaces', [...this._state.workspaces, aws])
+    }
+
+    /**
+     * count workspace usage
+     */
+    if (aws) {
+      const newWorkspaceVisitCount = this.state.visitCount[aws.id]
+        ? this.state.visitCount[aws.id] + 1
+        : 1
+
+      const visitCount = {
+        ...this.state.visitCount,
+        [aws.id]: newWorkspaceVisitCount
+      }
+
+      /**
+       * remove ids from `visitCount` list that aren't in workspace list (cleanup)
+       */
+      for (const id of Object.keys(visitCount)) {
+        if (!this._state.workspaces.find((w) => w.id === id)) {
+          delete visitCount[id]
+        }
+      }
+
+      this.updateState('visitCount', visitCount)
     }
   }
 }

--- a/packages/widget-projects/src/extension.ts
+++ b/packages/widget-projects/src/extension.ts
@@ -64,7 +64,22 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
         }
       }
 
+      const lastVisited = {
+        ...this._state.lastVisited,
+        [aws.id]: Date.now()
+      }
+
+      /**
+       * remove ids from `lastVisited` list that aren't in workspace list (cleanup)
+       */
+      for (const id of Object.keys(lastVisited)) {
+        if (!this._state.workspaces.find((w) => w.id === id)) {
+          delete lastVisited[id]
+        }
+      }
+
       this.updateState('visitCount', visitCount)
+      this.updateState('lastVisited', lastVisited)
     }
   }
 }

--- a/packages/widget-projects/src/extension.ts
+++ b/packages/widget-projects/src/extension.ts
@@ -13,7 +13,6 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
     channel: vscode.OutputChannel
   ) {
     super(context, channel, STATE_KEY, DEFAULT_CONFIGURATION, DEFAULT_STATE)
-
     const aws = this.getActiveWorkspace()
     /**
      * add new workspace to list
@@ -47,12 +46,12 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
      * count workspace usage
      */
     if (aws) {
-      const newWorkspaceVisitCount = this.state.visitCount[aws.id]
-        ? this.state.visitCount[aws.id] + 1
+      const newWorkspaceVisitCount = this._state.visitCount[aws.id]
+        ? this._state.visitCount[aws.id] + 1
         : 1
 
       const visitCount = {
-        ...this.state.visitCount,
+        ...this._state.visitCount,
         [aws.id]: newWorkspaceVisitCount
       }
 

--- a/packages/widget-projects/src/types.ts
+++ b/packages/widget-projects/src/types.ts
@@ -1,6 +1,6 @@
 import type { Workspace, ContextProperties } from '@vscode-marquee/utils'
 
-export type WorkspaceSortOrder = 'alphabetical' | 'usage' | 'visits'
+export type WorkspaceSortOrder = 'alphabetical' | 'usage' | 'visits' | 'recent'
 
 export interface Configuration {
   workspaceFilter?: string
@@ -10,7 +10,7 @@ export interface Configuration {
 
 export interface State {
   workspaces: Workspace[]
-  lastVisited: string | null
+  lastVisited: Record<string, number>
   visitCount: Record<string, number>
 }
 

--- a/packages/widget-projects/src/types.ts
+++ b/packages/widget-projects/src/types.ts
@@ -1,6 +1,6 @@
 import type { Workspace, ContextProperties } from '@vscode-marquee/utils'
 
-export type WorkspaceSortOrder = 'alphabetical' | 'usage'
+export type WorkspaceSortOrder = 'alphabetical' | 'usage' | 'visits'
 
 export interface Configuration {
   workspaceFilter?: string
@@ -10,6 +10,8 @@ export interface Configuration {
 
 export interface State {
   workspaces: Workspace[]
+  lastVisited: string | null
+  visitCount: Record<string, number>
 }
 
 export interface Context extends ContextProperties<Configuration & State> {

--- a/packages/widget-projects/tests/Widget.test.tsx
+++ b/packages/widget-projects/tests/Widget.test.tsx
@@ -11,7 +11,11 @@ declare const window: MarqueeWindow
 (connect as jest.Mock).mockReset()
 
 const TEST_STATE = {
-  lastVisited: 'fa0f7de4-f283-51b2-b4e5-5f47355c0b78',
+  lastVisited: {
+    'f894785a-deec-5197-81bb-975087ae3595': 10,
+    'fa0f7de4-f283-51b2-b4e5-5f47355c0b78:': 20,
+    '86fc84c1-6fee-5479-9930-3094fc498792': 30
+  },
   visitCount: {
     '86fc84c1-6fee-5479-9930-3094fc498792': 1,
     'f894785a-deec-5197-81bb-975087ae3595': 2,
@@ -46,6 +50,7 @@ it('renders component correctly', async () => {
 
   ;(connect as jest.Mock).mockReturnValue({
     openProjectInNewWindow: false,
+    lastVisited: {},
     setWorkspaceFilter,
     workspaces: [
       {
@@ -163,6 +168,28 @@ it('should render projects by visits', () => {
   expect(listElems.map((el) => el.innerHTML)).toEqual([
     '/workspaceB',
     '/workspaceA',
+    '/workspaceC'
+  ])
+})
+
+it('should render projects by last visits', () => {
+  (connect as jest.Mock).mockReturnValue({
+    ...TEST_STATE,
+    workspaceSortOrder: 'recent'
+  })
+  render(
+    <GlobalProvider>
+      <WorkspaceProvider>
+        <Widget.component />
+      </WorkspaceProvider>
+    </GlobalProvider>
+  )
+
+  const listElems = screen.getAllByTestId('projectPath')
+  expect(listElems).toHaveLength(3)
+  expect(listElems.map((el) => el.innerHTML)).toEqual([
+    '/workspaceA',
+    '/workspaceB',
     '/workspaceC'
   ])
 })

--- a/packages/widget-projects/tests/Widget.test.tsx
+++ b/packages/widget-projects/tests/Widget.test.tsx
@@ -1,20 +1,61 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/react'
-import { GlobalProvider } from '@vscode-marquee/utils'
+import { GlobalProvider, connect, MarqueeWindow } from '@vscode-marquee/utils'
 
 import Widget from '../src'
 import { WorkspaceProvider } from '../src/Context'
 
-declare const window: {
-  vscode: any
+declare const window: MarqueeWindow
+
+(connect as jest.Mock).mockReset()
+
+const TEST_STATE = {
+  lastVisited: 'fa0f7de4-f283-51b2-b4e5-5f47355c0b78',
+  visitCount: {
+    '86fc84c1-6fee-5479-9930-3094fc498792': 1,
+    'f894785a-deec-5197-81bb-975087ae3595': 2,
+    'fa0f7de4-f283-51b2-b4e5-5f47355c0b78:': 3
+  },
+  workspaces: [
+    {
+      id: 'fa0f7de4-f283-51b2-b4e5-5f47355c0b78',
+      name: 'workspaceC',
+      type: 'folder',
+      path: '/workspaceC'
+    }, {
+      id: '86fc84c1-6fee-5479-9930-3094fc498792',
+      name: 'workspaceA',
+      type: 'folder',
+      path: '/workspaceA'
+    }, {
+      id: 'f894785a-deec-5197-81bb-975087ae3595',
+      name: 'workspaceB',
+      type: 'folder',
+      path: '/workspaceB'
+    }
+  ]
 }
 
 beforeEach(() => {
-  window.vscode = { postMessage: jest.fn() }
+  window.vscode = { postMessage: jest.fn() } as any
 })
 
-test('renders component correctly', async () => {
+it('renders component correctly', async () => {
+  const setWorkspaceFilter: any = jest.fn()
+
+  ;(connect as jest.Mock).mockReturnValue({
+    openProjectInNewWindow: false,
+    setWorkspaceFilter,
+    workspaces: [
+      {
+        id: '012c54122a42128fc1b4ec29a7b5609995f41a5c',
+        name: 'example',
+        type: 'folder',
+        path: '/Users/christianbromann/Sites/WebdriverIO/example',
+      },
+    ],
+  })
   render(
     <GlobalProvider>
       <WorkspaceProvider>
@@ -35,10 +76,93 @@ test('renders component correctly', async () => {
   expect(window.vscode.postMessage).toBeCalledTimes(0)
   await userEvent.click(screen.getByLabelText('Open Folder'))
   expect(window.vscode.postMessage).toBeCalledTimes(1)
-  expect(window.vscode.postMessage.mock.calls).toMatchSnapshot()
-  window.vscode.postMessage.mockClear()
+  expect((window.vscode.postMessage as jest.Mock).mock.calls).toMatchSnapshot()
+  ;(window.vscode.postMessage as jest.Mock).mockClear()
 
   await userEvent.click(screen.getByLabelText('Open Recent'))
   expect(window.vscode.postMessage).toBeCalledTimes(1)
-  expect(window.vscode.postMessage.mock.calls).toMatchSnapshot()
+  expect((window.vscode.postMessage as jest.Mock).mock.calls).toMatchSnapshot()
+
+  expect(setWorkspaceFilter).toBeCalledWith('foo')
+})
+
+it('should render projects alphabetrically', () => {
+  (connect as jest.Mock).mockReturnValue(TEST_STATE)
+  render(
+    <GlobalProvider>
+      <WorkspaceProvider>
+        <Widget.component />
+      </WorkspaceProvider>
+    </GlobalProvider>
+  )
+
+  const listElems = screen.getAllByTestId('projectPath')
+  expect(listElems).toHaveLength(3)
+  expect(listElems.map((el) => el.innerHTML)).toEqual([
+    '/workspaceA',
+    '/workspaceB',
+    '/workspaceC'
+  ])
+})
+
+it('should render projects by usage', () => {
+  window.marqueeStateConfiguration['@vscode-marquee/notes-widget'].state.notes = [
+    // workspaceC
+    { workspaceId: 'fa0f7de4-f283-51b2-b4e5-5f47355c0b78' },
+    // workspaceB
+    { workspaceId: 'f894785a-deec-5197-81bb-975087ae3595' },
+    // workspaceA
+    { workspaceId: '86fc84c1-6fee-5479-9930-3094fc498792' }
+  ]
+  window.marqueeStateConfiguration['@vscode-marquee/todo-widget'].state.todos = [
+    // workspaceC
+    { workspaceId: 'fa0f7de4-f283-51b2-b4e5-5f47355c0b78' }
+  ]
+  window.marqueeStateConfiguration['@vscode-marquee/snippets-widget'].state.snippets = [
+    // workspaceC
+    { workspaceId: 'fa0f7de4-f283-51b2-b4e5-5f47355c0b78' },
+    // workspaceB
+    { workspaceId: 'f894785a-deec-5197-81bb-975087ae3595' }
+  ] as any
+  (connect as jest.Mock).mockReturnValue({
+    ...TEST_STATE,
+    workspaceSortOrder: 'usage',
+  })
+  render(
+    <GlobalProvider>
+      <WorkspaceProvider>
+        <Widget.component />
+      </WorkspaceProvider>
+    </GlobalProvider>
+  )
+
+  const listElems = screen.getAllByTestId('projectPath')
+  expect(listElems).toHaveLength(3)
+  expect(listElems.map((el) => el.innerHTML)).toEqual([
+    '/workspaceC',
+    '/workspaceB',
+    '/workspaceA'
+  ])
+})
+
+it('should render projects by visits', () => {
+  (connect as jest.Mock).mockReturnValue({
+    ...TEST_STATE,
+    workspaceSortOrder: 'visits'
+  })
+  render(
+    <GlobalProvider>
+      <WorkspaceProvider>
+        <Widget.component />
+      </WorkspaceProvider>
+    </GlobalProvider>
+  )
+
+  const listElems = screen.getAllByTestId('projectPath')
+  expect(listElems).toHaveLength(3)
+  expect(listElems.map((el) => el.innerHTML)).toEqual([
+    '/workspaceB',
+    '/workspaceA',
+    '/workspaceC'
+  ])
 })

--- a/packages/widget-projects/tests/extension.test.tsx
+++ b/packages/widget-projects/tests/extension.test.tsx
@@ -1,0 +1,113 @@
+import { ProjectsExtensionManager } from '../src/extension'
+
+jest.mock('@vscode-marquee/utils/extension', () => class ExtensionManagerMock {
+  public getActiveWorkspace = jest.fn().mockReturnValue({
+    id: 'foobar',
+    path: '/foo/bar'
+  })
+  public updateState = jest.fn()
+  public _state = {
+    workspaces: [] as any,
+    visitCount: {}
+  }
+
+  /**
+   * use fake params to modify the behavior of mock
+   */
+  constructor (ws: any) {
+    ws.id && this._state.workspaces.push(ws)
+  }
+})
+
+test('should update state with new workspaces', () => {
+  const ws = { id: 'foobar', path: '/foo/bar' }
+  const manager = new ProjectsExtensionManager({} as any, {} as any)
+  expect(manager.updateState).toBeCalledWith('workspaces', [ws])
+})
+
+test('should count workspace visit', () => {
+  const ws = { id: 'foobar', path: '/foo/bar' }
+  const manager = new ProjectsExtensionManager(ws as any, {} as any)
+  expect(manager.updateState).toBeCalledWith('visitCount', { [ws.id]: 1 })
+})
+
+// export class ProjectsExtensionManager extends ExtensionManager<State, Configuration> {
+//   constructor (
+//     context: vscode.ExtensionContext,
+//     channel: vscode.OutputChannel
+//   ) {
+//     super(context, channel, STATE_KEY, DEFAULT_CONFIGURATION, DEFAULT_STATE)
+
+//     const aws = this.getActiveWorkspace()
+//     /**
+//      * add new workspace to list
+//      */
+//     if (
+//       /**
+//        * the current workspace can be detected
+//        */
+//       aws &&
+//       /**
+//        * the workspace path is not a number
+//        * (happens e.g. when connecting to docker container)
+//        */
+//       isNaN(Number(aws.path)) &&
+//       /**
+//        * the workspace isn't part of the existing list
+//        */
+//       !this._state.workspaces.find((ws: any) => ws.id === aws.id) &&
+//       /**
+//        * we are not running on a remote machine, this is necessary
+//        * because we aren't able to connect to remote VSCode instances
+//        * through `vscode.openFolder`
+//        * see more: https://github.com/microsoft/vscode-remote-release/issues/6243
+//        */
+//       typeof vscode.env.remoteName === 'undefined'
+//     ) {
+//       this.updateState('workspaces', [...this._state.workspaces, aws])
+//     }
+
+//     /**
+//      * count workspace usage
+//      */
+//     if (aws) {
+//       const newWorkspaceVisitCount = this.state.visitCount[aws.id]
+//         ? this.state.visitCount[aws.id] + 1
+//         : 1
+
+//       const visitCount = {
+//         ...this.state.visitCount,
+//         [aws.id]: newWorkspaceVisitCount
+//       }
+
+//       /**
+//        * remove ids from `visitCount` list that aren't in workspace list (cleanup)
+//        */
+//       for (const id of Object.keys(visitCount)) {
+//         if (!this._state.workspaces.find((w) => w.id === id)) {
+//           delete visitCount[id]
+//         }
+//       }
+
+//       this.updateState('visitCount', visitCount)
+//     }
+//   }
+// }
+
+// export function activate (
+//   context: vscode.ExtensionContext,
+//   channel: vscode.OutputChannel
+// ) {
+//   const stateManager = new ProjectsExtensionManager(context, channel)
+
+//   return {
+//     marquee: {
+//       disposable: stateManager,
+//       defaultState: stateManager.state,
+//       defaultConfiguration: stateManager.configuration,
+//       setup: stateManager.setBroadcaster.bind(stateManager)
+//     }
+//   }
+// }
+
+// export * from './types'

--- a/packages/widget-projects/tests/extension.test.tsx
+++ b/packages/widget-projects/tests/extension.test.tsx
@@ -31,83 +31,8 @@ test('should count workspace visit', () => {
   expect(manager.updateState).toBeCalledWith('visitCount', { [ws.id]: 1 })
 })
 
-// export class ProjectsExtensionManager extends ExtensionManager<State, Configuration> {
-//   constructor (
-//     context: vscode.ExtensionContext,
-//     channel: vscode.OutputChannel
-//   ) {
-//     super(context, channel, STATE_KEY, DEFAULT_CONFIGURATION, DEFAULT_STATE)
-
-//     const aws = this.getActiveWorkspace()
-//     /**
-//      * add new workspace to list
-//      */
-//     if (
-//       /**
-//        * the current workspace can be detected
-//        */
-//       aws &&
-//       /**
-//        * the workspace path is not a number
-//        * (happens e.g. when connecting to docker container)
-//        */
-//       isNaN(Number(aws.path)) &&
-//       /**
-//        * the workspace isn't part of the existing list
-//        */
-//       !this._state.workspaces.find((ws: any) => ws.id === aws.id) &&
-//       /**
-//        * we are not running on a remote machine, this is necessary
-//        * because we aren't able to connect to remote VSCode instances
-//        * through `vscode.openFolder`
-//        * see more: https://github.com/microsoft/vscode-remote-release/issues/6243
-//        */
-//       typeof vscode.env.remoteName === 'undefined'
-//     ) {
-//       this.updateState('workspaces', [...this._state.workspaces, aws])
-//     }
-
-//     /**
-//      * count workspace usage
-//      */
-//     if (aws) {
-//       const newWorkspaceVisitCount = this.state.visitCount[aws.id]
-//         ? this.state.visitCount[aws.id] + 1
-//         : 1
-
-//       const visitCount = {
-//         ...this.state.visitCount,
-//         [aws.id]: newWorkspaceVisitCount
-//       }
-
-//       /**
-//        * remove ids from `visitCount` list that aren't in workspace list (cleanup)
-//        */
-//       for (const id of Object.keys(visitCount)) {
-//         if (!this._state.workspaces.find((w) => w.id === id)) {
-//           delete visitCount[id]
-//         }
-//       }
-
-//       this.updateState('visitCount', visitCount)
-//     }
-//   }
-// }
-
-// export function activate (
-//   context: vscode.ExtensionContext,
-//   channel: vscode.OutputChannel
-// ) {
-//   const stateManager = new ProjectsExtensionManager(context, channel)
-
-//   return {
-//     marquee: {
-//       disposable: stateManager,
-//       defaultState: stateManager.state,
-//       defaultConfiguration: stateManager.configuration,
-//       setup: stateManager.setBroadcaster.bind(stateManager)
-//     }
-//   }
-// }
-
-// export * from './types'
+test('should remember last visit', () => {
+  const ws = { id: 'foobar', path: '/foo/bar' }
+  const manager = new ProjectsExtensionManager(ws as any, {} as any)
+  expect(manager.updateState).toBeCalledWith('lastVisited', { [ws.id]: expect.any(Number) })
+})


### PR DESCRIPTION
Based on suggestion in #156 

This patch allows to sort projects by amount if times the workspace was visited, e.g.:
![demovists](https://user-images.githubusercontent.com/731337/176475522-82314c3f-416d-482d-9688-fe840d15600d.gif)

The demo shows how switching between workspace C and B makes workspace B rang from rank 3 to rank 2. After that switching from workspace C and A makes workspace A retake rank 2.