### PR TITLE
Don't switch workspace if we clicked on 'Remove Project' in popover

### DIFF
--- a/packages/widget-projects/src/components/ListItem.tsx
+++ b/packages/widget-projects/src/components/ListItem.tsx
@@ -80,6 +80,13 @@ let ProjectListItem = ({ workspace }: ProjectListItemProps) => {
     }
 
     /**
+     * don't trigger if we clicked something within `ItemPop
+     */
+    if (document.querySelector('#todo-item-popover')?.contains(target)) {
+      return
+    }
+
+    /**
      * or if we onfocus the opened more popup
      */
     if (


### PR DESCRIPTION
fixes #143