### PR TITLE
Minor improvements adding a selection to clipboard or notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,15 +151,8 @@
       },
       {
         "command": "marquee.todo.addEditor",
-        "title": "Marquee: Add Selection to Todos",
-        "category": "Marquee",
-        "enablement": "editorHasSelection"
-      },
-      {
-        "command": "marquee.todo.addEditor",
-        "title": "Add to Todos",
-        "category": "Marquee",
-        "enablement": "!editorHasSelection"
+        "title": "Marquee: Add to Todos",
+        "category": "Marquee"
       },
       {
         "command": "marquee.todo.move",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
       },
       {
         "command": "marquee.todo.addEditor",
-        "title": "Add Selection to Todos",
+        "title": "Marquee: Add Selection to Todos",
         "category": "Marquee",
         "enablement": "editorHasSelection"
       },
@@ -184,7 +184,7 @@
       },
       {
         "command": "marquee.note.addEditor",
-        "title": "Add Selection to Notes",
+        "title": "Marquee: Add Selection to Notes",
         "category": "Marquee",
         "enablement": "editorHasSelection"
       },
@@ -225,7 +225,7 @@
       },
       {
         "command": "marquee.snippet.addEditor",
-        "title": "Add Selection to Snippets",
+        "title": "Marquee: Add Selection to Clipboard",
         "category": "Marquee",
         "enablement": "editorHasSelection"
       },

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -289,7 +289,7 @@ export function activate (
   /**
    * extension host has access to sentry events
    */
-  const env = process.env.NODE_ENV === 'development' 
+  const env = process.env.NODE_ENV === 'development'
     ? 'development'
     : 'production'
 
@@ -298,7 +298,7 @@ export function activate (
     beforeSend (event){
       if(event.environment === 'development'){
         return null
-      } 
+      }
       return event
     },
     environment: env,

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -282,7 +282,11 @@ let Notes = ({ ToggleFullScreen }: MarqueeWidgetProps) => {
                   startIcon={<LinkIcon />}
                   disableFocusRipple
                   onClick={() => jumpTo(note)}
-                  style={{ padding: '0 5px' }}
+                  style={{
+                    padding: '0 5px',
+                    background: 'transparent',
+                    color: 'inherit'
+                  }}
                 >
                   {noteLinkFileName}
                 </Button>

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -168,14 +168,13 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       } as vscode.TextEditor)
 
       const todoMatch = textWholeLine.match(TODO)
-      if (!todoMatch || !todoMatch[0]) {
-        return vscode.window.showWarningMessage('Marquee: no text selected')
-      }
 
       /**
        * check if line contains todo match and then strip it
        */
-      text = textWholeLine.slice(textWholeLine.indexOf(todoMatch[0]))
+      text = todoMatch && todoMatch[0]
+        ? textWholeLine.slice(textWholeLine.indexOf(todoMatch[0]))
+        : textWholeLine
       path = pathWholeLine
     }
 


### PR DESCRIPTION
This patch contains two small improvements:

- it adds a prefix to the "Add Selection to *" to ensure that people understand that clipboard is not the system clipboard|
  ![Screenshot 2022-06-30 at 00 02 32](https://user-images.githubusercontent.com/731337/176553117-bd9fc912-04d1-47e9-b94c-5a4c61300694.png)
- it makes the background of the link transparent like it was in notes
  before
  ![Screenshot 2022-06-30 at 00 03 23](https://user-images.githubusercontent.com/731337/176553212-2b4600c6-c495-40e1-bf64-2cd04adcfcd6.png)
  after:
  ![Screenshot 2022-06-30 at 00 03 39](https://user-images.githubusercontent.com/731337/176553267-6c2db3df-ccaf-4d80-a1c8-47572a304dc3.png)
- it seems that VSCode doesn't allow to have the same context commands for when `editorHasSelection` or not, so I simplified this for todos and allow to always add a line to the todo list. In case nothing got selected we pick the whole line as label
 ![todo123](https://user-images.githubusercontent.com/731337/176555995-4d5abf64-6b48-44ac-a96b-bdd11ab27b86.gif)
 