### PR TITLE
[🐛 Bug]: Widget size is broken when re-adding them to the dashboard

### DIFF
--- a/packages/gui/src/Container.tsx
+++ b/packages/gui/src/Container.tsx
@@ -81,11 +81,21 @@ export const WidgetLayout = React.memo(() => {
         })
       })
 
-      if (modified) {
-        return newLayouts
-      } else {
-        return mode.layouts
+      /**
+       * in case a widget got removed and added back to the dashboard
+       * the values for width and height are auto set to `1`. This little
+       * logic ensures that we have a minimal width and height for widgets.
+       */
+      const layout = modified ? newLayouts : mode.layouts
+      for (const [, l] of Object.entries(layout)) {
+        for (const w of l) {
+          if (w.w === 1 && w.h === 1) {
+            w.w = 3
+            w.h = 12
+          }
+        }
       }
+      return layout
     }
     return null
   }, [mode, modes, modeName])

--- a/packages/widget-markdown/src/extension.ts
+++ b/packages/widget-markdown/src/extension.ts
@@ -28,7 +28,6 @@ const uriToMarkdownDocument = (uri: string, isRemote: boolean) => ({
 
 export class MarkdownExtensionManager extends ExtensionManager<State, Configuration> {
   constructor (context: vscode.ExtensionContext, channel: vscode.OutputChannel) {
-    console.log('GOOO', DEFAULT_CONFIGURATION)
     super(
       context,
       channel,


### PR DESCRIPTION
### VSCode Environment

Version: 1.67.2
Commit: c3511e6c69bb39013c4a4b7b9566ec1ca73fc4d5
Date: 2022-05-17T18:20:57.384Z (1 wk ago)
Electron: 17.4.1
Chromium: 98.0.4758.141
Node.js: 16.13.0
V8: 9.8.177.13-electron.0
OS: Darwin x64 21.5.0

### Marquee Version

v3.1.1653582143

### Workspace Type

Local Workspace

### What happened?

When widgets are removed and re-added they wind up in a state without height/width info.

<img width="139" alt="Screen Shot 2022-05-26 at 16 23 58" src="https://user-images.githubusercontent.com/5144/170595268-a1cd70b4-0487-41c1-801e-f74668a9be8e.png">


### What is your expected behavior?

Maybe we set a minimum height for widgets to get them back to where you want them.

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues