### PR TITLE
[🐛 Bug]: let user know that notes or todos are available when creating items in workspace scope

### DIFF
--- a/packages/extension/src/gui.view.ts
+++ b/packages/extension/src/gui.view.ts
@@ -19,6 +19,14 @@ declare const BACKEND_BASE_URL: string
 declare const BACKEND_GEO_URL: string
 declare const BACKEND_FWDGEO_URL: string
 
+interface NotificationParams {
+  type: string
+  message: string
+  detail?: string
+  modal?: boolean
+  items?: string[]
+}
+
 export class MarqueeGui extends EventEmitter {
   private panel: vscode.WebviewPanel | null = null
   private guiActive: boolean = false
@@ -290,16 +298,21 @@ export class MarqueeGui extends EventEmitter {
     vscode.commands.executeCommand(command, undefined, options)
   }
 
-  private _handleNotifications ({ type, message }: { type: string, message: string }) {
+  private _handleNotifications ({ type, message, detail, modal, items }: NotificationParams) {
+    let answer: Thenable<string | undefined>
     switch (type) {
       case 'error':
-        vscode.window.showErrorMessage(message)
+        answer = vscode.window.showErrorMessage(message, { detail, modal }, ...(items || []))
         break
       case 'warning':
-        vscode.window.showWarningMessage(message)
+        answer = vscode.window.showWarningMessage(message, { detail, modal }, ...(items || []))
         break
       default:
-        vscode.window.showInformationMessage(message)
+        answer = vscode.window.showInformationMessage(message, { detail, modal }, ...(items || []))
+    }
+
+    if (items && Array.isArray(items) && items[0] === 'Switch to Global Scope') {
+      answer.then(() => this.stateMgr.global.updateState('globalScope', true, true))
     }
   }
 }

--- a/packages/extension/tests/gui.view.test.ts
+++ b/packages/extension/tests/gui.view.test.ts
@@ -89,13 +89,29 @@ test('_executeCommand', () => {
 test('_handleNotifications', () => {
   const gui = new MarqueeGui(context, stateMgr, channel)
   gui['_handleNotifications']({ type: 'error', message: 'foobar' })
-  expect(vscode.window.showErrorMessage).toBeCalledWith('foobar')
+  expect(vscode.window.showErrorMessage)
+    .toBeCalledWith('foobar', { detail: undefined, modal: undefined })
 
-  gui['_handleNotifications']({ type: 'warning', message: 'foobar' })
-  expect(vscode.window.showWarningMessage).toBeCalledWith('foobar')
+  gui['_handleNotifications']({
+    type: 'warning',
+    message: 'foobar',
+    modal: true,
+    detail: 'barfoo',
+    items: ['foo', 'bar']
+  })
+  expect(vscode.window.showWarningMessage).toBeCalledWith(
+    'foobar',
+    { modal: true, detail: 'barfoo' },
+    'foo',
+    'bar'
+  )
 
-  gui['_handleNotifications']({ type: 'anything', message: 'foobar' })
-  expect(vscode.window.showInformationMessage).toBeCalledWith('foobar')
+  gui['_handleNotifications']({
+    type: 'anything',
+    message: 'foobar',
+    items: ['foo']
+  })
+  expect(vscode.window.showInformationMessage).toBeCalledWith('foobar', {}, 'foo')
 })
 
 test('open an already open webview', async () => {
@@ -160,8 +176,12 @@ test('_handleWebviewMessage', async () => {
   expect(gui['_executeCommand']).toBeCalledWith('foo', 0, ['foo', 'bar'])
   expect(gui['_executeCommand']).toBeCalledWith('bar', 1, ['foo', 'bar'])
 
-  await gui['_handleWebviewMessage']({ west: { notify: { message: 'foobar' } } })
-  expect(gui['_handleNotifications']).toBeCalledWith({ message: 'foobar' })
+  await gui['_handleWebviewMessage']({ west: {
+    notify: { message: 'foobar', details: 'barfoo', modal: true }
+  } })
+  expect(gui['_handleNotifications']).toBeCalledWith(
+    { message: 'foobar', details: 'barfoo', modal: true }
+  )
 
   expect(gui['guiActive']).toBe(false)
   await gui['_handleWebviewMessage']({ ready: true })

--- a/packages/gui/src/components/Navigation.tsx
+++ b/packages/gui/src/components/Navigation.tsx
@@ -267,16 +267,10 @@ const Navigation = () => {
                     size="small"
                     onClick={() => setGlobalScope(!globalScope)}
                   >
-                    <Badge
-                      color="secondary"
-                      variant="dot"
-                      overlap="circular"
-                      badgeContent={globalScope ? 1 : 0}
-                    >
-                      {globalScope ? 
-                        <LanguageIcon fontSize="small"/> : <WorkspacesIcon fontSize="small" />
-                      }
-                    </Badge>
+                    {globalScope
+                      ? <LanguageIcon fontSize="small"/>
+                      : <WorkspacesIcon fontSize="small" />
+                    }
                   </IconButton>
                 </Tooltip>
               </Grid>)}

--- a/packages/utils/tests/extension.test.ts
+++ b/packages/utils/tests/extension.test.ts
@@ -196,9 +196,14 @@ test('updateState', async () => {
     { defaultState: true }
   )
   manager.emit = jest.fn()
-  await manager.updateState('defaultState', 'some new state' as any)
+  manager['_tangle'] = { broadcast: jest.fn() } as any
+  await manager.updateState('defaultState', 'some new state' as any, true)
   expect(manager.state.defaultState).toBe('some new state')
   expect(manager.emit).toBeCalledWith('stateUpdate', {
+    defaultState: 'some new state',
+    defaultConfig: 'old config'
+  })
+  expect(manager['_tangle']?.broadcast).toBeCalledWith({
     defaultState: 'some new state',
     defaultConfig: 'old config'
   })

--- a/packages/widget-github/src/Context.tsx
+++ b/packages/widget-github/src/Context.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useEffect } from 'react'
 import { connect, getEventListener, MarqueeWindow } from '@vscode-marquee/utils'
 
+import { GithubTrendingDialog } from './components/TrendingDialog'
 import { fetchData, getFromCache } from './utils'
 import type { Context, Trend, Configuration, Since, SpokenLanguage, SinceConfiguration, Events } from './types'
 
@@ -35,17 +36,11 @@ const TrendProvider = ({ children }: Props) => {
   }
 
   const _updateLanguage = (language?: SpokenLanguage) => {
-    if (!language?.name) {
-      return
-    }
-    providerValues.setLanguage(language.name || '')
+    providerValues.setLanguage(language?.name || '')
   }
 
   const _updateSpoken = (spoken?: SpokenLanguage) => {
-    if (!spoken?.name) {
-      return
-    }
-    providerValues.setSpoken(spoken.name || '')
+    providerValues.setSpoken(spoken?.name || '')
   }
 
   useEffect(() => {
@@ -102,6 +97,7 @@ const TrendProvider = ({ children }: Props) => {
       }}
     >
       {children}
+      { showDialog && ( <GithubTrendingDialog close={() => setShowDialog(false)} /> )}
     </TrendContext.Provider>
   )
 }

--- a/packages/widget-github/src/components/Filter.tsx
+++ b/packages/widget-github/src/components/Filter.tsx
@@ -61,7 +61,6 @@ let Filter = () => {
 
   const open = Boolean(anchorEl)
   const id = open ? 'github-filter-popover' : undefined
-  const badgeContent = (trendFilter || '').length
 
   return (
     <div>
@@ -70,7 +69,7 @@ let Filter = () => {
           color="secondary"
           variant="dot"
           overlap="circular"
-          badgeContent={badgeContent}
+          invisible={!Boolean((trendFilter || '').length)}
         >
           <SearchIcon fontSize="small" />
         </Badge>

--- a/packages/widget-github/src/components/TrendingDialog.tsx
+++ b/packages/widget-github/src/components/TrendingDialog.tsx
@@ -50,7 +50,11 @@ const SpokenLanguageOption = () => {
           display="name"
           value={value}
           isOptionEqualToValue={isOptionEqualToValue(spokenLanguages[0])}
-          onChange={(e: any, v: SpokenLanguage) => _updateSpoken(v)}
+          onChange={(e: any, v: SpokenLanguage) => {
+            console.log('UPDATE TO v', v || '')
+
+            _updateSpoken(v || '')
+          }}
         />
       </Grid>
     </Grid>
@@ -121,7 +125,7 @@ const SinceOption = () => {
   )
 }
 
-const GithubTrendingDialog = React.memo(({ close }: { close: () => void }) => {
+export const GithubTrendingDialog = React.memo(({ close }: { close: () => void }) => {
   return (
     <DialogContainer fullWidth={true} onClose={close}>
       <DialogTitle onClose={close}>Github Settings</DialogTitle>
@@ -148,29 +152,19 @@ const GithubTrendingDialog = React.memo(({ close }: { close: () => void }) => {
 })
 
 const TrendingDialogLauncher = () => {
-  const { language, since, spoken, showDialog, setShowDialog } = useContext(TrendContext)
-
-  /**
-   * show badge if settings are changed from default
-   */
-  const badgeContent = (since || spoken || language)
-    ? 1
-    : 0
+  const { language, since, spoken, setShowDialog } = useContext(TrendContext)
 
   return (
-    <>
-      <IconButton aria-label="filter-settings" onClick={() => setShowDialog(true)} size="small">
-        <Badge
-          color="secondary"
-          variant="dot"
-          overlap="circular"
-          badgeContent={badgeContent}
-        >
-          <SettingsIcon fontSize="small" />
-        </Badge>
-      </IconButton>
-      { showDialog && ( <GithubTrendingDialog close={() => setShowDialog(false)} /> )}
-    </>
+    <IconButton aria-label="filter-settings" onClick={() => setShowDialog(true)} size="small">
+      <Badge
+        color="secondary"
+        variant="dot"
+        overlap="circular"
+        invisible={!Boolean(((since !== 'Weekly') || spoken || language))}
+      >
+        <SettingsIcon fontSize="small" />
+      </Badge>
+    </IconButton>
   )
 }
 

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useMemo, useCallback, useState } from 'react'
-import { Grid, Typography, TextField, IconButton, Button, ClickAwayListener, Popper, Paper } from '@mui/material'
+import { Grid, Typography, TextField, IconButton, Button, ClickAwayListener, Popper, Paper, Link } from '@mui/material'
 import LinkIcon from '@mui/icons-material/Link'
 import ClearIcon from '@mui/icons-material/Clear'
 import AddCircleIcon from '@mui/icons-material/AddCircle'
@@ -44,7 +44,7 @@ interface RowRendererProps {
 }
 
 const WidgetBody = ({ notes, note } : { notes: Note[], note: any }) => {
-  const { globalScope } = useContext(GlobalContext)
+  const { globalScope, setGlobalScope } = useContext(GlobalContext)
   const {
     _updateNote,
     setNoteFilter,
@@ -191,27 +191,54 @@ const WidgetBody = ({ notes, note } : { notes: Note[], note: any }) => {
                   }}
                 >
                   {notesArr.length === 0 && (
-                    <Grid
-                      container
-                      style={{ height: '100%' }}
-                      alignItems="center"
-                      justifyContent="center"
-                      direction="column"
-                    >
-                      <Grid item>
-                        <Typography>Nothing here yet.</Typography>
+                    <>
+                      <Grid
+                        container
+                        style={{ height: '80%' }}
+                        alignItems="center"
+                        justifyContent="center"
+                        direction="column"
+                      >
+                        <Grid item>
+                          <Typography>Nothing here yet.</Typography>
+                        </Grid>
+                        <Grid item>&nbsp;</Grid>
+                        <Grid item>
+                          <Button
+                            startIcon={<AddCircleIcon />}
+                            variant="outlined"
+                            onClick={() => setShowAddDialog(true)}
+                          >
+                            Create a Note
+                          </Button>
+                        </Grid>
                       </Grid>
-                      <Grid item>&nbsp;</Grid>
-                      <Grid item>
-                        <Button
-                          startIcon={<AddCircleIcon />}
-                          variant="outlined"
-                          onClick={() => setShowAddDialog(true)}
-                        >
-                          Create a note
-                        </Button>
-                      </Grid>
-                    </Grid>
+                      {((noteFilter && noteFilter.length) || (!globalScope && notes.length)) && (
+                        <Grid container>
+                          <Grid item textAlign={'center'} width={'100%'}>
+                            {/* Notify user why they don't see any todos if they have
+                                a filter set or are in workspace scope while todo is
+                                in global scope
+                            */}
+                            {noteFilter && noteFilter.length > 0
+                              ? <>
+                                No Notes found, seems you have a filter set.<br />
+                                <Link href="#" onClick={() => setNoteFilter('')}>Clear Filter</Link>
+                              </>
+                              : <>
+                                There {notes.length === 1
+                                  ? <>is <b style={{ fontWeight: 'bold' }}>1</b> note</>
+                                  : <>are <b style={{ fontWeight: 'bold' }}>{notes.length}</b> notes</>
+                                } in Global Scope.<br />
+                                <Link href="#" onClick={() => setGlobalScope(true)}>
+                                  Switch to Global Scope
+                                </Link>
+                              </>
+                            }
+                          </Grid>
+                        </Grid>
+                      )}
+                    </>
                   )}
                   {notesArr.length !== 0 && note && (
                     <NoteEditor
@@ -295,7 +322,7 @@ let Notes = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidg
         <Grid item>
           <ToggleFullScreen />
         </Grid>
-        {!fullscreenMode && 
+        {!fullscreenMode &&
           <Grid item>
             <Dragger />
           </Grid>

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -180,7 +180,7 @@ const WidgetBody = ({ notes, note } : { notes: Note[], note: any }) => {
                 </Grid>
               </Grid>
             </div>
-            <div style={{ height: '100%' }}>
+            <div style={{ height: '100%' }} data-testid="widgetBody">
               <Grid container style={{ width: '100%', height: '100%' }}>
                 <Grid
                   item
@@ -213,8 +213,8 @@ const WidgetBody = ({ notes, note } : { notes: Note[], note: any }) => {
                           </Button>
                         </Grid>
                       </Grid>
-                      {((noteFilter && noteFilter.length) || (!globalScope && notes.length)) && (
-                        <Grid container>
+                      {Boolean(((noteFilter && noteFilter.length) || (!globalScope && notes.length))) && (
+                        <Grid container data-testid="noteExistanceNotif">
                           <Grid item textAlign={'center'} width={'100%'}>
                             {/* Notify user why they don't see any todos if they have
                                 a filter set or are in workspace scope while todo is

--- a/packages/widget-notes/src/dialogs/AddDialog.tsx
+++ b/packages/widget-notes/src/dialogs/AddDialog.tsx
@@ -7,7 +7,7 @@ import {
 } from '@mui/material'
 import { SplitButton } from '@vscode-marquee/widget'
 import { DialogTitle, DialogContainer } from '@vscode-marquee/dialog'
-import { theme, MarqueeWindow } from '@vscode-marquee/utils'
+import { theme, MarqueeWindow, GlobalContext } from '@vscode-marquee/utils'
 
 import NoteContext from '../Context'
 import NoteEditor from '../components/Editor'
@@ -16,6 +16,7 @@ declare const window: MarqueeWindow
 const options = ['Add to Workspace', 'Add as Global Note']
 
 const AddDialog = React.memo(({ close }: { close: () => void }) => {
+  const { globalScope } = useContext(GlobalContext)
   const { _addNote, setNoteSelected } = useContext(NoteContext)
   const [error, setError] = useState(false)
   const [body, setBody] = useState('')
@@ -27,6 +28,15 @@ const AddDialog = React.memo(({ close }: { close: () => void }) => {
     if (title.trim() === '') {
       setError(true)
       return
+    }
+
+    if (!isWorkspaceTodo && !globalScope) {
+      window.vscode.postMessage({
+        west: { notify: {
+          message: 'A new Note was created in the Global Scope.',
+          items: ['Switch to Global Scope']
+        }}
+      })
     }
 
     setNoteSelected(_addNote({ title, body, text }, isWorkspaceTodo))

--- a/packages/widget-notes/tests/AddNote.test.tsx
+++ b/packages/widget-notes/tests/AddNote.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
+// @ts-expect-error
+import { GlobalProvider, providerValues } from '@vscode-marquee/utils'
+
+import Widget from '../src'
+import { NoteProvider } from '../src/Context'
+
+
+test('renders component correctly', async () => {
+  const { container } = render(
+    <GlobalProvider>
+      <NoteProvider>
+        <Widget.component />
+      </NoteProvider>
+    </GlobalProvider>
+  )
+  expect(screen.queryByText('Add Note')).not.toBeInTheDocument()
+  expect(screen.getByText('Create a Note')).toBeInTheDocument()
+  await userEvent.click(screen.getByText('Create a Note'))
+
+  expect(screen.getByText('Add Note')).toBeInTheDocument()
+  expect(screen.getByPlaceholderText('Title of Note')).toBeInTheDocument()
+  expect(container.querySelector('.ql-editor')).toBeTruthy()
+
+  await userEvent.type(screen.getByPlaceholderText('Title of Note'), 'o')
+  await userEvent.type(container.querySelector('.noteEditorContainer-add')!, 'baaar{enter}')
+
+  await userEvent.click(screen.getByText('Add to Workspace'))
+  expect(providerValues.setNotes).toBeCalledTimes(1)
+  expect(providerValues.setNoteSelected).toBeCalledTimes(1)
+})

--- a/packages/widget-notes/tests/Widget.test.tsx
+++ b/packages/widget-notes/tests/Widget.test.tsx
@@ -1,33 +1,93 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
+// @ts-expect-error mock feature
+import { GlobalProvider, connect, setGlobalScope } from '@vscode-marquee/utils'
 import { render, screen } from '@testing-library/react'
-// @ts-expect-error
-import { GlobalProvider, providerValues } from '@vscode-marquee/utils'
 
-import Widget from '../src'
 import { NoteProvider } from '../src/Context'
+import Widget from '../src'
 
+describe('Notes Widget', () => {
+  it('should render no notification if there are no notes', () => {
+    (connect as jest.Mock).mockReturnValue({
+      notes: [],
+      globalScope: false
+    })
 
-test('renders component correctly', async () => {
-  const { container } = render(
-    <GlobalProvider>
-      <NoteProvider>
-        <Widget.component />
-      </NoteProvider>
-    </GlobalProvider>
-  )
-  expect(screen.queryByText('Add Note')).not.toBeInTheDocument()
-  expect(screen.getByText('Create a note')).toBeInTheDocument()
-  await userEvent.click(screen.getByText('Create a note'))
+    render(
+      <GlobalProvider>
+        <NoteProvider>
+          <Widget.component />
+        </NoteProvider>
+      </GlobalProvider>
+    )
 
-  expect(screen.getByText('Add Note')).toBeInTheDocument()
-  expect(screen.getByPlaceholderText('Title of Note')).toBeInTheDocument()
-  expect(container.querySelector('.ql-editor')).toBeTruthy()
+    expect(screen.queryByTestId('noteExistanceNotif')).not.toBeInTheDocument()
+  })
 
-  await userEvent.type(screen.getByPlaceholderText('Title of Note'), 'o')
-  await userEvent.type(container.querySelector('.noteEditorContainer-add')!, 'baaar{enter}')
+  it('should render notification when in workspace scope', async () => {
+    (connect as jest.Mock).mockReturnValue({
+      setNoteSelected: jest.fn(),
+      notes: [{ id: 123 }],
+      globalScope: false
+    })
 
-  await userEvent.click(screen.getByText('Add to Workspace'))
-  expect(providerValues.setNotes).toBeCalledTimes(1)
-  expect(providerValues.setNoteSelected).toBeCalledTimes(1)
+    render(
+      <GlobalProvider>
+        <NoteProvider>
+          <Widget.component />
+        </NoteProvider>
+      </GlobalProvider>
+    )
+
+    expect(screen.getByTestId('noteExistanceNotif')).toBeInTheDocument()
+    expect(screen.getByText('There is note in Global Scope.'))
+      .toBeInTheDocument()
+
+    expect(setGlobalScope).toBeCalledTimes(0)
+    await userEvent.click(screen.getByText('Switch to Global Scope'))
+    expect(setGlobalScope).toBeCalledWith(true)
+  })
+
+  it('should render notification when in workspace scope with multiple notes', () => {
+    (connect as jest.Mock).mockReturnValue({
+      setNoteSelected: jest.fn(),
+      notes: [{ id: 123 }, { id: 321 }],
+      globalScope: false
+    })
+
+    render(
+      <GlobalProvider>
+        <NoteProvider>
+          <Widget.component />
+        </NoteProvider>
+      </GlobalProvider>
+    )
+    expect(screen.getByText('There are notes in Global Scope.'))
+      .toBeInTheDocument()
+  })
+
+  it('should render notification when in filter is set', async () => {
+    const setNoteFilter = jest.fn()
+    ;(connect as jest.Mock).mockReturnValue({
+      setNoteSelected: jest.fn(),
+      notes: [{ id: 123 }, { id: 321 }],
+      globalScope: false,
+      noteFilter: 'foobar',
+      setNoteFilter
+    })
+
+    render(
+      <GlobalProvider>
+        <NoteProvider>
+          <Widget.component />
+        </NoteProvider>
+      </GlobalProvider>
+    )
+    expect(setNoteFilter).toBeCalledTimes(0)
+    expect(screen.getByText('No Notes found, seems you have a filter set.'))
+      .toBeInTheDocument()
+    await userEvent.click(screen.getByText('Clear Filter'))
+    expect(setNoteFilter).toBeCalledWith('')
+  })
 })

--- a/packages/widget-projects/src/components/Filter.tsx
+++ b/packages/widget-projects/src/components/Filter.tsx
@@ -70,7 +70,7 @@ let ProjectsFilter = () => {
           color="secondary"
           variant="dot"
           overlap="circular"
-          badgeContent={Boolean(workspaceFilter?.length)}
+          invisible={!Boolean(workspaceFilter?.length)}
         >
           <SearchIcon fontSize="small" />
         </Badge>

--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -160,7 +160,7 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
                   </Grid>
                 </Grid>
                 {((todoFilter && todoFilter.length) || (!globalScope && todosInGlobalScope > 0)) && (
-                  <Grid container>
+                  <Grid container data-testid="noteExistanceNotif">
                     <Grid item textAlign={'center'} width={'100%'}>
                       {/* Notify user why they don't see any todos if they have
                           a filter set or are in workspace scope while todo is

--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react'
 import Typography from '@mui/material/Typography'
 import AddCircle from '@mui/icons-material/AddCircleOutlined'
-import { ClickAwayListener, Grid, Button, IconButton, Paper, Popper } from '@mui/material'
+import { ClickAwayListener, Grid, Button, IconButton, Paper, Popper, Link } from '@mui/material'
 import { List, arrayMove } from 'react-movable'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCloud, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
@@ -11,7 +11,7 @@ import {
   bindPopper
 } from 'material-ui-popup-state/hooks'
 
-import { GlobalContext, DoubleClickHelper, MarqueeWindow, MarqueeEvents, getEventListener } from '@vscode-marquee/utils'
+import { GlobalContext, DoubleClickHelper, MarqueeEvents, getEventListener } from '@vscode-marquee/utils'
 import wrapper, { Dragger, HeaderWrapper } from '@vscode-marquee/widget'
 import { FeatureInterestDialog } from '@vscode-marquee/dialog'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
@@ -21,10 +21,9 @@ import TodoPop from './components/Pop'
 import TodoInfo from './components/Info'
 import TodoFilter from './components/Filter'
 import TodoItem from './components/Item'
-import { Events } from './types'
+import { filterItems } from './utils'
+import type { Events } from './types'
 
-
-declare const window: MarqueeWindow
 
 let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidgetProps) => {
   const eventListener = getEventListener<Events & MarqueeEvents>()
@@ -35,8 +34,9 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
     todos,
     hide,
     todoFilter,
+    setTodoFilter
   } = useContext(TodoContext)
-  const { globalScope } = useContext(GlobalContext)
+  const { globalScope, setGlobalScope } = useContext(GlobalContext)
   const [showCloudSyncFeature, setShowCloudSyncFeature] = useState(false)
 
   const _isInterestedInSyncFeature = (interested: boolean) => {
@@ -82,7 +82,7 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
         <Grid item>
           <ToggleFullScreen />
         </Grid>
-        {!fullscreenMode && 
+        {!fullscreenMode &&
           <Grid item>
             <Dragger />
           </Grid>
@@ -91,56 +91,12 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
     </Grid>
   )
 
-  let filteredItems = useMemo(() => {
-    let filteredItems = todos
-
-    if (!globalScope) {
-      let filteredArr = filteredItems.filter((item) => {
-        if (item['workspaceId'] === window.activeWorkspace?.id) {
-          return true
-        }
-      })
-      filteredItems = filteredArr
-    }
-
-    if (!showArchived) {
-      let filteredArr = filteredItems.filter((item) => {
-        if (!item.hasOwnProperty('archived') || item.archived === false) {
-          return true
-        }
-      })
-      filteredItems = filteredArr
-    }
-
-    if (todoFilter) {
-      let filteredArr = filteredItems.filter((item) => {
-        let inBody =
-          item.body.toLowerCase().indexOf(todoFilter.toLowerCase()) !== -1
-        let inTags = false
-
-        if (item.tags && item.tags.length !== 0) {
-          inTags =
-            JSON.stringify(item.tags)
-              .toLowerCase()
-              .indexOf(todoFilter.toLowerCase()) !== -1
-        }
-
-        if (inBody || inTags) {
-          return true
-        }
-      })
-      filteredItems = filteredArr
-    }
-
-    if (hide) {
-      let hideArr = filteredItems.filter((item) => {
-        return item.checked === false
-      })
-      filteredItems = hideArr
-    }
-
-    return filteredItems
-  }, [todos, globalScope, hide, todoFilter, showArchived])
+  const filteredItems = useMemo(() => (
+    filterItems(todos, { globalScope, hide, todoFilter, showArchived })
+  ), [todos, globalScope, hide, todoFilter, showArchived])
+  const todosInGlobalScope = useMemo(() => (
+    filterItems(todos, { globalScope: true, hide, showArchived }).length
+  ), [todos, globalScope, hide, showArchived])
 
   return (
     <>
@@ -190,18 +146,47 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
         >
           <Grid item xs style={{ overflow: 'auto' }}>
             {filteredItems.length === 0 && (
-              <Grid
-                container
-                alignItems="center"
-                justifyContent="center"
-                style={{ height: '80%', width: '100%' }}
-              >
-                <Grid item>
-                  <Button startIcon={<AddCircle />} variant="outlined" onClick={() => setShowAddDialog(true)}>
-                    Create a todo
-                  </Button>
+              <>
+                <Grid
+                  container
+                  alignItems="center"
+                  justifyContent="center"
+                  style={{ height: '80%', width: '100%' }}
+                >
+                  <Grid item>
+                    <Button startIcon={<AddCircle />} variant="outlined" onClick={() => setShowAddDialog(true)}>
+                      Create a Todo
+                    </Button>
+                  </Grid>
                 </Grid>
-              </Grid>
+                {((todoFilter && todoFilter.length) || (!globalScope && todosInGlobalScope > 0)) && (
+                  <Grid container>
+                    <Grid item textAlign={'center'} width={'100%'}>
+                      {/* Notify user why they don't see any todos if they have
+                          a filter set or are in workspace scope while todo is
+                          in global scope
+                      */}
+                      {todoFilter && todoFilter.length > 0
+                        ? <>
+                          No Todos found, seems you have a filter set.<br />
+                          <Link href="#" onClick={() => setTodoFilter('')}>Clear Filter</Link>
+                        </>
+                        : <>
+                          There {filterItems(todos, { globalScope: true, hide, showArchived }).length === 1
+                            ? <>is <b style={{ fontWeight: 'bold' }}>1</b> todo</>
+                            : <>are <b style={{ fontWeight: 'bold' }}>{
+                              filterItems(todos, { globalScope: true, hide, showArchived }).length
+                            }</b> todos</>
+                          } in Global Scope.<br />
+                          <Link href="#" onClick={() => setGlobalScope(true)}>
+                            Switch to Global Scope
+                          </Link>
+                        </>
+                      }
+                    </Grid>
+                  </Grid>
+                )}
+              </>
             )}
             <List
               lockVertically={true}

--- a/packages/widget-todo/src/components/Filter.tsx
+++ b/packages/widget-todo/src/components/Filter.tsx
@@ -69,7 +69,7 @@ let TodoFilter = () => {
           color="secondary"
           variant="dot"
           overlap="circular"
-          badgeContent={Boolean(todoFilter?.length)}
+          invisible={!Boolean(todoFilter?.length)}
         >
           <SearchIcon fontSize="small" />
         </Badge>

--- a/packages/widget-todo/src/dialogs/AddDialog.tsx
+++ b/packages/widget-todo/src/dialogs/AddDialog.tsx
@@ -6,7 +6,7 @@ import {
   TextField,
 } from '@mui/material'
 
-import { theme, MarqueeWindow } from '@vscode-marquee/utils'
+import { theme, MarqueeWindow, GlobalContext } from '@vscode-marquee/utils'
 import { SplitButton } from '@vscode-marquee/widget'
 import { DialogTitle, DialogContainer } from '@vscode-marquee/dialog'
 
@@ -17,6 +17,7 @@ declare const window: MarqueeWindow
 const options = ['Add to Workspace', 'Add as Global Todo']
 
 const TodoAddDialog = React.memo(({ close }: { close: () => void }) => {
+  const { globalScope } = useContext(GlobalContext)
   const { _addTodo } = useContext(TodoContext)
   const [error, setError] = useState(false)
   const [body, setBody] = useState('')
@@ -25,6 +26,14 @@ const TodoAddDialog = React.memo(({ close }: { close: () => void }) => {
   const submit = (index: number) => {
     const isWorkspaceTodo = index === 0
     if (body !== '') {
+      if (!isWorkspaceTodo && !globalScope) {
+        window.vscode.postMessage({
+          west: { notify: {
+            message: 'A new Todo was created in the Global Scope.',
+            items: ['Switch to Global Scope']
+          }}
+        })
+      }
       _addTodo(body, tags, isWorkspaceTodo)
     } else {
       setError(true)

--- a/packages/widget-todo/src/utils.ts
+++ b/packages/widget-todo/src/utils.ts
@@ -1,0 +1,58 @@
+import type { MarqueeWindow } from '@vscode-marquee/utils'
+import { Todo } from './types'
+
+declare const window: MarqueeWindow
+
+interface FilterParams {
+  globalScope?: boolean
+  hide?: boolean
+  todoFilter?: string
+  showArchived?: boolean
+}
+export function filterItems (todos: Todo[], params: FilterParams) {
+  let filteredItems = todos
+
+  if (!params.globalScope) {
+    filteredItems = filteredItems.filter((item) => {
+      if (item['workspaceId'] === window.activeWorkspace?.id) {
+        return true
+      }
+    })
+  }
+
+  if (!params.showArchived) {
+    filteredItems = filteredItems.filter((item) => {
+      if (!item.hasOwnProperty('archived') || item.archived === false) {
+        return true
+      }
+    })
+  }
+
+  if (params.todoFilter) {
+    filteredItems = filteredItems.filter((item) => {
+      let inBody = item.body
+        .toLowerCase()
+        .indexOf(params.todoFilter!.toLowerCase()) !== -1
+      let inTags = false
+
+      if (item.tags && item.tags.length !== 0) {
+        inTags =
+          JSON.stringify(item.tags)
+            .toLowerCase()
+            .indexOf(params.todoFilter!.toLowerCase()) !== -1
+      }
+
+      if (inBody || inTags) {
+        return true
+      }
+    })
+  }
+
+  if (params.hide) {
+    filteredItems = filteredItems.filter((item) => {
+      return item.checked === false
+    })
+  }
+
+  return filteredItems
+}

--- a/packages/widget-todo/tests/AddDialog.test.tsx
+++ b/packages/widget-todo/tests/AddDialog.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
+import { GlobalProvider } from '@vscode-marquee/utils'
+
+import Widget from '../src'
+import { TodoProvider } from '../src/Context'
+
+test('renders component correctly', async () => {
+  render(
+    <GlobalProvider>
+      <TodoProvider>
+        <Widget.component />
+      </TodoProvider>
+    </GlobalProvider>
+  )
+  expect(screen.getByText('Create a Todo')).toBeInTheDocument()
+  await userEvent.click(screen.getByText('Create a Todo'))
+  await userEvent.type(screen.getByPlaceholderText('Type your todo...'), 'Some Todo')
+  await userEvent.click(screen.getByText('Add to Workspace'))
+})

--- a/packages/widget-todo/tests/Widget.test.tsx
+++ b/packages/widget-todo/tests/Widget.test.tsx
@@ -1,21 +1,90 @@
 import React from 'react'
 import userEvent from '@testing-library/user-event'
+// @ts-expect-error mock feature
+import { GlobalProvider, connect, setGlobalScope } from '@vscode-marquee/utils'
 import { render, screen } from '@testing-library/react'
-import { GlobalProvider } from '@vscode-marquee/utils'
 
-import Widget from '../src'
 import { TodoProvider } from '../src/Context'
+import Widget from '../src'
 
-test('renders component correctly', async () => {
-  render(
-    <GlobalProvider>
-      <TodoProvider>
-        <Widget.component />
-      </TodoProvider>
-    </GlobalProvider>
-  )
-  expect(screen.getByText('Create a todo')).toBeInTheDocument()
-  await userEvent.click(screen.getByText('Create a todo'))
-  await userEvent.type(screen.getByPlaceholderText('Type your todo...'), 'Some Todo')
-  await userEvent.click(screen.getByText('Add to Workspace'))
+describe('Todo Widget', () => {
+  it('should render no notification if there are no todos', () => {
+    (connect as jest.Mock).mockReturnValue({
+      todos: [],
+      globalScope: false
+    })
+
+    render(
+      <GlobalProvider>
+        <TodoProvider>
+          <Widget.component />
+        </TodoProvider>
+      </GlobalProvider>
+    )
+
+    expect(screen.queryByTestId('noteExistanceNotif')).not.toBeInTheDocument()
+  })
+
+  it('should render notification when in workspace scope', async () => {
+    (connect as jest.Mock).mockReturnValue({
+      todos: [{ id: 123 }],
+      globalScope: false
+    })
+
+    render(
+      <GlobalProvider>
+        <TodoProvider>
+          <Widget.component />
+        </TodoProvider>
+      </GlobalProvider>
+    )
+
+    expect(screen.getByTestId('noteExistanceNotif')).toBeInTheDocument()
+    expect(screen.getByText('There is todo in Global Scope.'))
+      .toBeInTheDocument()
+
+    expect(setGlobalScope).toBeCalledTimes(0)
+    await userEvent.click(screen.getByText('Switch to Global Scope'))
+    expect(setGlobalScope).toBeCalledWith(true)
+  })
+
+  it('should render notification when in workspace scope with multiple todos', () => {
+    (connect as jest.Mock).mockReturnValue({
+      todos: [{ id: 123 }, { id: 321 }],
+      globalScope: false
+    })
+
+    render(
+      <GlobalProvider>
+        <TodoProvider>
+          <Widget.component />
+        </TodoProvider>
+      </GlobalProvider>
+    )
+    expect(screen.getByText('There are todos in Global Scope.'))
+      .toBeInTheDocument()
+  })
+
+  it('should render notification when in filter is set', async () => {
+    const setTodoFilter = jest.fn()
+    ;(connect as jest.Mock).mockReturnValue({
+      todos: [{ id: 123 }, { id: 321 }],
+      globalScope: false,
+      todoFilter: 'foobar',
+      setTodoFilter
+    })
+
+    render(
+      <GlobalProvider>
+        <TodoProvider>
+          <Widget.component />
+        </TodoProvider>
+      </GlobalProvider>
+    )
+    expect(setTodoFilter).toBeCalledTimes(0)
+    expect(screen.getByText('No Todos found, seems you have a filter set.'))
+      .toBeInTheDocument()
+    await userEvent.click(screen.getByText('Clear Filter'))
+    expect(setTodoFilter).toBeCalledWith('')
+  })
 })

--- a/test/pageobjects/locators.ts
+++ b/test/pageobjects/locators.ts
@@ -42,7 +42,7 @@ export const githubTrendItem = {
 export const todoWidget = {
   ...commonWidgetLocators,
   elem: webview.widget('todo'),
-  createTodoBtn: 'button=Create a todo',
+  createTodoBtn: 'button=Create a Todo',
   addTodoBtn: 'button[aria-label="add-todo"]',
   items: 'div[aria-label="todo-item"]',
   filterBtn: 'button[aria-label="todo-filter"]',

--- a/test/pageobjects/widgets/todo.ts
+++ b/test/pageobjects/widgets/todo.ts
@@ -67,6 +67,7 @@ export class TodoWidget extends BasePage<typeof todoWidgetLocators, typeof locat
     const checkbox = $(this.locators.autoDetectCheckbox)
     await checkbox.waitForExist()
 
+    await $(this.locators.autoDetectCheckbox).waitForExist()
     const isAutoDetectEnabled = Boolean(
       await $(this.locators.autoDetectCheckbox).$('input[type="checkbox"]').getValue()
     )
@@ -74,6 +75,7 @@ export class TodoWidget extends BasePage<typeof todoWidgetLocators, typeof locat
       await $(this.locators.autoDetectCheckbox).click()
     }
 
+    await $(this.locators.hideCompleteCheckbox).waitForExist()
     const isHideCompleted = Boolean(
       await $(this.locators.hideCompleteCheckbox).$('input[type="checkbox"]').getValue()
     )
@@ -81,6 +83,7 @@ export class TodoWidget extends BasePage<typeof todoWidgetLocators, typeof locat
       await $(this.locators.hideCompleteCheckbox).click()
     }
 
+    await $(this.locators.showArchivedCheckbox).waitForExist()
     const showArchived = Boolean(
       await $(this.locators.showArchivedCheckbox).$('input[type="checkbox"]').getValue()
     )


### PR DESCRIPTION
### What happened?

If someone creates a _global_ todo / note / snippet within workspace mode, there can be confusions because you don't see any items being created given you created them in the wrong mode.

### What is your expected behavior?

I could imagine two solutions to that:

- check if there list contains no items but the other mode has some, then show a message notifying that these are available in the order mode and help the user to switch over
- or allow displaying global items within workspace mode

Demo:
![betterNotes](https://user-images.githubusercontent.com/731337/181279706-1b59e0c6-28ae-4608-af9a-150259f6c571.gif)
![betterTodo](https://user-images.githubusercontent.com/731337/181280159-5d8f9482-75c8-48ae-9708-b11e9701d58e.gif)

