### PR TITLE
DRY implementation on nav dropdown ux

### DIFF
--- a/packages/widget-github/src/Widget.tsx
+++ b/packages/widget-github/src/Widget.tsx
@@ -6,26 +6,17 @@ import {
   Chip, 
   Avatar, 
   CircularProgress, 
-  IconButton, 
-  Popper, 
-  Paper, 
-  ClickAwayListener 
 } from '@mui/material'
 import AvatarGroup from '@mui/material/AvatarGroup'
 import StarIcon from '@mui/icons-material/Star'
 import StarHalfIcon from '@mui/icons-material/StarHalf'
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCodeBranch } from '@fortawesome/free-solid-svg-icons/faCodeBranch'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 
-import wrapper, { Dragger, HeaderWrapper, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, NavIconDropdown } from '@vscode-marquee/widget'
 import { NetworkError } from '@vscode-marquee/utils'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -63,7 +54,7 @@ let Github = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWid
   }, [trends, trendFilter])
 
   const NavButtons = () => (
-    <Grid item>
+    <Grid item zIndex={100} style={{opacity: 1}}>
       <Grid
         container
         justifyContent="right"
@@ -100,21 +91,12 @@ let Github = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWid
           <Typography variant="subtitle1">Trending on Github</Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-github' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-github'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal={true} sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-markdown/src/Widget.tsx
+++ b/packages/widget-markdown/src/Widget.tsx
@@ -1,19 +1,16 @@
 import React, { useState } from 'react'
 import {
   Box,
-  ClickAwayListener,
   Grid,
   IconButton,
   ListItem,
   ListItemText,
-  Paper,
-  Popper,
   TextField,
   Tooltip,
   Typography,
 } from '@mui/material'
 
-import { faCopy, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import { faCopy } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faMarkdown } from '@fortawesome/free-brands-svg-icons/faMarkdown'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
@@ -23,12 +20,8 @@ import { AutoSizer, List } from 'react-virtualized'
 import ReactMarkdown from 'react-markdown'
 import { MarkdownProvider, useMarkdownContext } from './Context'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
-import wrapper, { Dragger, HeaderWrapper, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, NavIconDropdown } from '@vscode-marquee/widget'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
 const Markdown = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidgetProps) => {
@@ -106,21 +99,12 @@ const Markdown = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : Marque
           <Typography variant="subtitle1">Markdown</Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-markdown' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-markdown'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-news/src/Widget.tsx
+++ b/packages/widget-news/src/Widget.tsx
@@ -7,10 +7,6 @@ import {
   ListItem,
   ListItemText,
   ListItemAvatar,
-  IconButton,
-  Popper,
-  Paper,
-  ClickAwayListener
 } from '@mui/material'
 import Typography from '@mui/material/Typography'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -18,14 +14,8 @@ import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
 import type { Item } from 'rss-parser'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 
-import wrapper, { Dragger, HeaderWrapper } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, NavIconDropdown } from '@vscode-marquee/widget'
 import { NetworkError } from '@vscode-marquee/utils'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -124,21 +114,12 @@ const News = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWid
           </Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-news' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-news'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-notes/src/Widget.tsx
+++ b/packages/widget-notes/src/Widget.tsx
@@ -1,15 +1,11 @@
 import React, { useContext, useEffect, useMemo, useCallback, useState } from 'react'
-import { Grid, Typography, TextField, IconButton, Button, ClickAwayListener, Popper, Paper } from '@mui/material'
+import { Grid, Typography, TextField, IconButton, Button } from '@mui/material'
 import LinkIcon from '@mui/icons-material/Link'
 import ClearIcon from '@mui/icons-material/Clear'
 import AddCircleIcon from '@mui/icons-material/AddCircle'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCloud, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import { faCloud } from '@fortawesome/free-solid-svg-icons'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
 import SplitterLayout from 'react-splitter-layout'
 import { List, AutoSizer } from 'react-virtualized'
@@ -22,7 +18,7 @@ import {
   MarqueeEvents,
   getEventListener,
 } from '@vscode-marquee/utils'
-import wrapper, { Dragger, HeaderWrapper, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, NavIconDropdown } from '@vscode-marquee/widget'
 import { FeatureInterestDialog } from '@vscode-marquee/dialog'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -338,21 +334,12 @@ let Notes = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidg
           </Grid>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-notes' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-notes'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-npm-stats/src/Widget.tsx
+++ b/packages/widget-npm-stats/src/Widget.tsx
@@ -1,16 +1,10 @@
 import React, { useContext, useRef, useEffect, useState } from 'react'
-import { Grid, Typography, CircularProgress, Button, IconButton, Popper, ClickAwayListener, Paper } from '@mui/material'
+import { Grid, Typography, CircularProgress, Button } from '@mui/material'
 import styled from '@emotion/styled'
 import 'react-vis/dist/style.css'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
-import wrapper, { Dragger, HeaderWrapper } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, NavIconDropdown } from '@vscode-marquee/widget'
 import { NetworkError, MarqueeWindow } from '@vscode-marquee/utils'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -129,7 +123,13 @@ let NPMStats = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeW
 
   const NavButtons = () => (
     <Grid item>
-      <Grid container justifyContent="right" direction={minimizeNavIcon ? 'column-reverse' : 'row'} spacing={1}>
+      <Grid 
+        container 
+        justifyContent="right" 
+        direction={minimizeNavIcon ? 'column-reverse' : 'row'} 
+        spacing={1} 
+        padding={minimizeNavIcon ? 0.5 : 0}
+      >
         <Grid item>
           <PopMenu />
         </Grid>
@@ -152,21 +152,12 @@ let NPMStats = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeW
           <Typography variant="subtitle1">NPM Statistics</Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-npm-stats' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-npm-stats'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-projects/src/Widget.tsx
+++ b/packages/widget-projects/src/Widget.tsx
@@ -1,16 +1,11 @@
 import React, { useContext, useMemo } from 'react'
-import { ClickAwayListener, Grid, Typography, List, IconButton, Button, Paper, Popper } from '@mui/material'
+import { Grid, Typography, List, IconButton, Button } from '@mui/material'
 import AddCircle from '@mui/icons-material/AddCircleOutlined'
 import PageviewIcon from '@mui/icons-material/Pageview'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
-import wrapper, { Dragger, HeaderWrapper } from '@vscode-marquee/widget'
+
+import wrapper, { Dragger, HeaderWrapper, NavIconDropdown } from '@vscode-marquee/widget'
 import { MarqueeWindow } from '@vscode-marquee/utils'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -135,21 +130,12 @@ let Projects = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeW
           <Typography variant="subtitle1">Projects</Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-projects' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-projects'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-snippets/src/Widget.tsx
+++ b/packages/widget-snippets/src/Widget.tsx
@@ -5,19 +5,13 @@ import {
   Typography,
   TextField,
   Button,
-  ClickAwayListener,
-  Popper,
-  Paper
 } from '@mui/material'
 import { AddCircle, Clear } from '@mui/icons-material'
 import LinkIcon from '@mui/icons-material/Link'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCloud, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import { faCloud } from '@fortawesome/free-solid-svg-icons'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
+
 
 import { 
   GlobalContext, 
@@ -27,7 +21,7 @@ import {
   getEventListener, 
   MarqueeEvents 
 } from '@vscode-marquee/utils'
-import wrapper, { Dragger, HeaderWrapper, HidePop } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, HidePop, NavIconDropdown } from '@vscode-marquee/widget'
 import { FeatureInterestDialog } from '@vscode-marquee/dialog'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -342,21 +336,12 @@ let Snippets = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeW
           </Grid>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-clipboard' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-clipboard'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -1,18 +1,14 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react'
 import Typography from '@mui/material/Typography'
 import AddCircle from '@mui/icons-material/AddCircleOutlined'
-import { ClickAwayListener, Grid, Button, IconButton, Paper, Popper } from '@mui/material'
+import { Grid, Button, IconButton } from '@mui/material'
 import { List, arrayMove } from 'react-movable'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCloud, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import { faCloud } from '@fortawesome/free-solid-svg-icons'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
 import { GlobalContext, DoubleClickHelper, MarqueeWindow, MarqueeEvents, getEventListener } from '@vscode-marquee/utils'
-import wrapper, { Dragger, HeaderWrapper } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, NavIconDropdown } from '@vscode-marquee/widget'
 import { FeatureInterestDialog } from '@vscode-marquee/dialog'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -158,21 +154,12 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
           </Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-todo' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-todo'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-weather/src/Widget.tsx
+++ b/packages/widget-weather/src/Widget.tsx
@@ -2,17 +2,12 @@ import React, { useContext } from 'react'
 
 // @ts-expect-error no types available
 import WeatherIcon from 'react-icons-weather'
-import { ClickAwayListener, Grid, Typography, CircularProgress, Box, IconButton, Paper, Popper } from '@mui/material'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import { Grid, Typography, CircularProgress, Box } from '@mui/material'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
+
 
 import { GlobalContext, NetworkError } from '@vscode-marquee/utils'
-import wrapper, { Dragger, HidePop, HeaderWrapper } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HidePop, HeaderWrapper, NavIconDropdown } from '@vscode-marquee/widget'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
 import WeatherContext, { WeatherProvider } from './Context'
@@ -226,21 +221,12 @@ const Weather = ({ ToggleFullScreen, fullscreenMode, minimizeNavIcon } : Marquee
           {!city && <Typography variant="subtitle1">Weather</Typography>}
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-weather' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-weather'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget-welcome/src/Widget.tsx
+++ b/packages/widget-welcome/src/Widget.tsx
@@ -1,15 +1,10 @@
 import React, { useContext } from 'react'
-import { ClickAwayListener, Grid, IconButton, Link, Popper, Paper, Typography } from '@mui/material'
+import { Grid, Link, Typography } from '@mui/material'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDiscord } from '@fortawesome/free-brands-svg-icons/faDiscord'
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import PopupState from 'material-ui-popup-state'
-import {
-  bindToggle,
-  bindPopper
-} from 'material-ui-popup-state/hooks'
 
-import wrapper, { Dragger, HeaderWrapper } from '@vscode-marquee/widget'
+import wrapper, { Dragger, HeaderWrapper, NavIconDropdown } from '@vscode-marquee/widget'
 import { NetworkError } from '@vscode-marquee/utils'
 import type { MarqueeWidgetProps } from '@vscode-marquee/widget'
 
@@ -129,21 +124,12 @@ let Welcome = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWi
           <Typography variant="subtitle1">Mailbox</Typography>
         </Grid>
         {minimizeNavIcon ?
-          <PopupState variant='popper' popupId='widget-welcome' disableAutoFocus>
+          <PopupState variant='popper' popupId='widget-welcome'>
             {(popupState) => {
               return (
-                <ClickAwayListener onClickAway={() => popupState.close()}>
-                  <Grid item xs={1}>
-                    <IconButton {...bindToggle(popupState)}>
-                      <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
-                    </IconButton>
-                    <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 100 }}>
-                      <Paper>
-                        <NavButtons />
-                      </Paper>
-                    </Popper>
-                  </Grid>
-                </ClickAwayListener>
+                <NavIconDropdown popupState={popupState}>
+                  <NavButtons />
+                </NavIconDropdown>
               )}}
           </PopupState>
           :

--- a/packages/widget/src/NavIconsDropdown.tsx
+++ b/packages/widget/src/NavIconsDropdown.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { ClickAwayListener, Grid, IconButton, Paper, Popper } from '@mui/material'
+import {
+  bindToggle,
+  bindPopper,
+  PopupState,
+  anchorRef
+} from 'material-ui-popup-state/hooks'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+
+interface NavIconDropdownPropTypes {
+  popupState: PopupState,
+  children: React.ReactChild,
+}
+const NavIconDropdown = ({ popupState, children } : NavIconDropdownPropTypes) => {
+  return (
+    <ClickAwayListener onClickAway={() => popupState.close()}>
+      <Grid item xs={1}>
+        <IconButton {...bindToggle(popupState)} ref={() => anchorRef(popupState)}>
+          <FontAwesomeIcon icon={faEllipsisV} fontSize={'small'} />
+        </IconButton>
+        <Popper {...bindPopper(popupState)} disablePortal sx={{ zIndex: 1000 }}
+          modifiers={[
+            {
+              name: 'flip',
+              enabled: false,
+              options: {
+                altBoundary: false,
+                rootBoundary: 'document',
+                padding: 8,
+              },
+            },
+            {
+              name: 'preventOverflow',
+              enabled: false,
+              options: {
+                altAxis: false,
+                altBoundary: false,
+                tether: false,
+                rootBoundary: 'document',
+                padding: 8,
+              },
+            },
+          ]}
+        >
+          <Paper className='tooltip' style={{ zIndex: 1000 }}>
+            {children}
+          </Paper>
+        </Popper>
+      </Grid>
+    </ClickAwayListener>
+  )
+}
+
+export default NavIconDropdown

--- a/packages/widget/src/ThirdPartyWidget.tsx
+++ b/packages/widget/src/ThirdPartyWidget.tsx
@@ -113,6 +113,28 @@ const ThirdPartyWidget = ({
                       disablePortal
                       anchorEl={() => ref?.current as any}
                       sx={{ zIndex:100 }}
+                      modifiers={[
+                        {
+                          name: 'flip',
+                          enabled: false,
+                          options: {
+                            altBoundary: true,
+                            rootBoundary: 'document',
+                            padding: 8,
+                          },
+                        },
+                        {
+                          name: 'preventOverflow',
+                          enabled: false,
+                          options: {
+                            altAxis: true,
+                            altBoundary: true,
+                            tether: true,
+                            rootBoundary: 'document',
+                            padding: 8,
+                          },
+                        },
+                      ]}
                     >
                       <Paper>
                         <NavButtons />

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -5,7 +5,8 @@ import ThirdPartyWidget from './ThirdPartyWidget'
 import HideWidgetContent from './HideWidgetContent'
 import SplitButton from './SplitButton'
 import HeaderWrapper from './HeaderWrapper'
+import NavIconDropdown from './NavIconsDropdown'
 
 export default WidgetWrapper
-export { Dragger, HidePop, ThirdPartyWidget, HideWidgetContent, SplitButton, HeaderWrapper }
+export { Dragger, HidePop, ThirdPartyWidget, HideWidgetContent, SplitButton, HeaderWrapper, NavIconDropdown }
 export * from './types'


### PR DESCRIPTION
DRY and avoid the popper from flipping on scroll. Should work as expected now.

old-
![lh-revamp-nav-toggle](https://user-images.githubusercontent.com/63378463/181378300-37b3a2bc-4850-4b9c-8b98-3e4c04d3089d.gif)

fix-
![lh-revamp-nav-toggle-fix](https://user-images.githubusercontent.com/63378463/181378289-5b16f935-c8e3-4d29-b21d-e84048a2809b.gif)
