### PR TITLE
[🐛 Bug]: Markdown widget not working with "virtual FS"?

### DIFF
--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -169,8 +169,8 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
   async emitStateUpdate (broadcastState?: boolean) {
     await this._context.globalState.update(this._key, this._state)
     this.emit('stateUpdate', this._state)
-    if (broadcastState) {
-      this._tangle!.broadcast(this._state as State & Configuration)
+    if (broadcastState && this._tangle) {
+      this._tangle.broadcast(this._state as State & Configuration)
     }
   }
 

--- a/packages/widget-markdown/src/Context.tsx
+++ b/packages/widget-markdown/src/Context.tsx
@@ -1,16 +1,21 @@
-import React, { createContext, useContext, useEffect } from 'react'
+import React, { createContext, useContext, useEffect, useState } from 'react'
 import { connect, getEventListener, MarqueeWindow } from '@vscode-marquee/utils'
 
-import type { State, Context } from './types'
+import type { State, Context, WidgetEvents, MarkdownDocument } from './types'
 
 declare const window: MarqueeWindow
 const MarkdownContext = createContext<Context>({} as Context)
 export const WIDGET_ID = '@vscode-marquee/markdown-widget'
 
 export const MarkdownProvider = ({ children }: { children: React.ReactElement }) => {
-  const widgetState = getEventListener<State>(WIDGET_ID)
-  const providerValues = connect<State>(window.marqueeStateConfiguration[WIDGET_ID].state, widgetState)
+  const [selectedMarkdownContent, setSelectedMarkdownContent] = useState<string>()
+  const [markdownDocuments, setMarkdownDocuments] = useState<MarkdownDocument[]>([])
+  const widgetState = getEventListener<State & WidgetEvents>(WIDGET_ID)
+  const providerValues = connect<State>(window.marqueeStateConfiguration[WIDGET_ID].state, widgetState as any)
   useEffect(() => {
+    widgetState.on('selectedMarkdownContent', setSelectedMarkdownContent)
+    widgetState.on('markdownDocuments', setMarkdownDocuments)
+
     return () => {
       widgetState.removeAllListeners()
     }
@@ -20,6 +25,8 @@ export const MarkdownProvider = ({ children }: { children: React.ReactElement })
     <MarkdownContext.Provider
       value={{
         ...providerValues,
+        selectedMarkdownContent,
+        markdownDocuments
       }}
     >
       {children}

--- a/packages/widget-markdown/src/Widget.tsx
+++ b/packages/widget-markdown/src/Widget.tsx
@@ -36,6 +36,9 @@ const Markdown = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : Marque
     setMarkdownDocumentSelected,
   } = useMarkdownContext()
 
+  console.log('markdownDocumentSelected', markdownDocumentSelected)
+  console.log('selectedMarkdownContent', selectedMarkdownContent)
+
   const markdownDocumentsToDisplay = filter
     ? markdownDocuments.filter((md) =>
       md.name.toLowerCase().includes(filter.toLowerCase())
@@ -83,7 +86,7 @@ const Markdown = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : Marque
         <Grid item>
           <ToggleFullScreen />
         </Grid>
-        {!fullscreenMode && 
+        {!fullscreenMode &&
           <Grid item>
             <Dragger />
           </Grid>

--- a/packages/widget-markdown/src/Widget.tsx
+++ b/packages/widget-markdown/src/Widget.tsx
@@ -38,6 +38,7 @@ const Markdown = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : Marque
 
   console.log('markdownDocumentSelected', markdownDocumentSelected)
   console.log('selectedMarkdownContent', selectedMarkdownContent)
+  console.log('markdownDocuments', markdownDocuments)
 
   const markdownDocumentsToDisplay = filter
     ? markdownDocuments.filter((md) =>

--- a/packages/widget-markdown/src/constants.ts
+++ b/packages/widget-markdown/src/constants.ts
@@ -5,5 +5,5 @@ export const DEFAULT_CONFIGURATION: Configuration = {
 }
 
 export const DEFAULT_STATE: State = {
-  markdownDocuments: []
+  markdownDocumentSelected: null
 }

--- a/packages/widget-markdown/src/types.ts
+++ b/packages/widget-markdown/src/types.ts
@@ -1,20 +1,23 @@
 import type { ContextProperties } from '@vscode-marquee/utils'
 
 export interface MarkdownDocument {
-  id: string;
-  name: string;
-  path: string;
-  isRemote: boolean;
+  id: string
+  name: string
+  path: string
+  isRemote: boolean
 }
 
 export interface Configuration {
   externalMarkdownFiles: string[]
 }
 
+export interface WidgetEvents {
+  markdownDocuments: MarkdownDocument[]
+  markdownDocumentSelected?: MarkdownDocument['id']
+}
+
 export interface State {
-  markdownDocuments: MarkdownDocument[];
-  markdownDocumentSelected?: MarkdownDocument['id'];
-  selectedMarkdownContent?: string;
+  markdownDocumentSelected: string | null
 }
 
 export interface Context extends ContextProperties<State> {}

--- a/packages/widget-markdown/src/types.ts
+++ b/packages/widget-markdown/src/types.ts
@@ -13,11 +13,14 @@ export interface Configuration {
 
 export interface WidgetEvents {
   markdownDocuments: MarkdownDocument[]
-  markdownDocumentSelected?: MarkdownDocument['id']
+  selectedMarkdownContent: string
 }
 
 export interface State {
   markdownDocumentSelected: string | null
 }
 
-export interface Context extends ContextProperties<State> {}
+export interface Context extends ContextProperties<State> {
+  markdownDocuments: MarkdownDocument[]
+  selectedMarkdownContent?: string
+}


### PR DESCRIPTION
### VSCode Environment

Version: 1.69.1
Commit: b06ae3b2d2dbfe28bca3134cc6be65935cdfea6a
Date: 2022-07-12T08:25:53.739Z
Browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36

### Marquee Version

v3.2.0

### Workspace Type

Codespaces

### What happened?

Readme files won't show even though present in the context repo.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/250527/178827358-bbdcb152-e37a-4d30-82bb-0d40bca9e8b7.png">


### What is your expected behavior?

All MD files show up in Markdown widget.

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues