### PR TITLE
refinement on wrapping on widget-todo

### DIFF
--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -55,6 +55,7 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
         spacing={1}
         alignItems="center"
         padding={minimizeNavIcon ? 0.5 : 0}
+        flexWrap={'nowrap'}
       >
         <Grid item>
           <TodoFilter />
@@ -103,8 +104,8 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
         />
       }
       <HeaderWrapper>
-        <Grid item xs={4}>
-          <Typography variant="subtitle1">
+        <Grid item xs={5}>
+          <Typography variant="subtitle1" noWrap>
             Todo
             <TodoInfo />
           </Typography>


### PR DESCRIPTION
done to avoid wrapping as such -

old
<img width="569" alt="Screen Shot 2022-07-29 at 12 22 09 PM" src="https://user-images.githubusercontent.com/63378463/181830165-b91b8bfb-37ec-4206-8429-c106a68ca9ac.png">
<img width="277" alt="Screen Shot 2022-07-29 at 12 22 05 PM" src="https://user-images.githubusercontent.com/63378463/181830172-e0dc0175-032d-4945-96e2-65e4e2a9f271.png">


fix -
<img width="275" alt="Screen Shot 2022-07-29 at 12 23 31 PM" src="https://user-images.githubusercontent.com/63378463/181830288-f07f831a-947f-429c-a318-7426fb6a7cd7.png">
<img width="566" alt="Screen Shot 2022-07-29 at 12 23 28 PM" src="https://user-images.githubusercontent.com/63378463/181830292-defe744f-311c-4212-b9be-29be03101612.png">


new