### PR TITLE
Make Marquee the giraffe show up

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
 		"menus": {
 			"touchBar": [
 				{
-					"command": "marquee.open"
+					"command": "marquee.touchbar"
 				}
 			],
 			"view/title": [


### PR DESCRIPTION
Likely broken during v1 -> v2 refactor. Bringing this back for Mac touchbar users.