### PR TITLE
[💡 Feature]: DOC - How to build a core widget

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,64 @@ Marquee maintains its codebase as a monorepo containing various of modules withi
 
 When creating a new widget, e.g. a foobar widget, add a new directory within that folder, e.g. `/packages/widget-foobar`, and follow the folder structure as other widget modules. The `package.json` should point to an entry file that exports basic widget information, e.g.:
 
+widget-foobar sample folder structure
+```
+packages
+...other packages
+└───widget-foobar
+    │   build
+    │   extension
+    │   │   package.json
+    │   src
+    │   │   constants.ts
+    │   │   extension.ts
+    │   │   index.tsx
+    │   │   types.ts
+    │   │   Widget.tsx
+    │   package.json
+    │   tsconfig.json
+```
+
+Create a `tsconfig.json` file in the widget-foobar root
+```json
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*",
+    "../../@types"
+  ]
+}
+```
+
+Create a `package.json` in the widget-foobar root
+```json
+{
+  "name": "@vscode-marquee/widget-foobar",
+  "description": "Marquee Foobar Widget",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "dependencies": {
+    "@vscode-marquee/utils": "^0.1.0",
+    "@vscode-marquee/widget": "^0.1.0"
+  }
+}
+```
+
+
+`packages/widget-foobar/src/index.tsx:`
+
+Setting marquee up with our `Widget.tsx` ui
 ```ts
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -82,8 +140,9 @@ export default {
 }
 ```
 
-Add the new package to the workspace list in [`/package.json`](https://github.com/stateful/vscode-marquee/blob/dcd2d832853c3b8be9d65b58e736c7d43cacdaf3/package.json#L48-L62) and import it in `/packages/gui/src/constants.ts` so it is loaded by the webview. A basic widget component looks as following:
+Add the new package to the workspace list in [`/package.json`](https://github.com/stateful/vscode-marquee/blob/dcd2d832853c3b8be9d65b58e736c7d43cacdaf3/package.json#L48-L62) also adding a new [`watch:foobar`](https://github.com/stateful/vscode-marquee/blob/main/package.json#L3383-L3399) script and import it in [`/packages/gui/src/constants.ts`](https://github.com/stateful/vscode-marquee/blob/main/packages/gui/src/constants.ts#L22-L33) so it is loaded by the webview. A basic `widget component` looks as following:
 
+`packages/widget-foobar/src/Widget.tsx:`
 ```ts
 import React, { useContext } from 'react'
 import { Grid, Typography } from '@mui/material'
@@ -157,9 +216,7 @@ const Foobar = ({ ToggleFullScreen, fullscreenMode, minimizeNavIcon }: MarqueeWi
 }
 
 export default wrapper((props: any) => (
-  <FoobarProvider>
-    <Foobar {...props} />
-  </FoobarProvider>
+  <Foobar {...props} />
 ), 'foobar')
 ```
 
@@ -167,6 +224,7 @@ export default wrapper((props: any) => (
 
 If you need to run certain code within the extension host, e.g. if you like fetch data for the widget, create an `extension` folder within the widget directory and point to a file that exports an `activate` method, e.g.:
 
+Create a `package/widget-foobar/extension/package.json`
 ```json
 {
   "name": "@vscode-marquee/widget-foobar-extension",
@@ -179,6 +237,7 @@ If you need to run certain code within the extension host, e.g. if you like fetc
 
 The `activate` method is called when Marquee as extension is activated. You can use it to iniate an `ExtensionManager` instance that simplifies state and configuration management for the widget, e.g.:
 
+`package/widget-foobar/src/extension.ts`
 ```ts
 import vscode from 'vscode'
 
@@ -212,7 +271,8 @@ export function activate (
 }
 ```
 
-Lastly import the method within the `packages/extension/src/stateManager.ts` so that the `activate` method will be called accordingly and the [`tangle`](https://www.npmjs.com/package/tangle) instance attached to the webview.
+Lastly import the method within the [`packages/extension/src/stateManager.ts`](https://github.com/stateful/vscode-marquee/blob/main/packages/extension/src/stateManager.ts#L11-L20) so that the `activate` method will be called accordingly and the [`tangle`](https://www.npmjs.com/package/tangle) instance attached to the webview.
+
 
 ## Reporting New Issues
 

--- a/packages/widget-welcome/src/extension.ts
+++ b/packages/widget-welcome/src/extension.ts
@@ -10,9 +10,7 @@ import type { State, Events, Configuration, Trick } from './types'
 declare const BACKEND_BASE_URL: string
 
 const STATE_KEY = 'widgets.welcome'
-const FETCH_INTERVAL = process.env.NODE_ENV === 'development'
-  ? 1000 * 5 // 5s
-  : 5 * 1000 * 60 // 5min
+const FETCH_INTERVAL = 5 * 1000 * 60 // 5min
 const AXIOS_RETRIES = process.env.NODE_ENV === 'development'
   ? 1
   : 10


### PR DESCRIPTION
### Is your feature request related to a problem?

No problem, we have documentation of intergrating marquee with external VS Code Extensions, but no core widget documentation in terms of making our own.

### Describe the solution you'd like.

Adds a section on the marquee docs on how to build a core widget - 

1. Documentation for team and other devs that want to add to the core widgets of marquee.
2. A list of steps to create core widget / simplification of getting a core widget started.

### Describe alternatives you've considered.

_No response_

### Additional context

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct