### PR TITLE
Enhance Project Items with Git Information

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/semi": [2, "never"],
-    "@typescript-eslint/restrict-template-expressions": 2,
     "@typescript-eslint/space-before-function-paren": [2, "always"],
     "@typescript-eslint/indent": [2, 2],
     "unused-imports/no-unused-imports": "error",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   }
 }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This extension contributes the following settings:
 * `marquee.widgets.todo.todoFilter` (type: `string`, default: `""`): Filter ToDos or their associated tags.
 * `marquee.widgets.todo.hide` (type: `boolean`, default: `false`): Hide completed ToDos.
 * `marquee.widgets.todo.showArchived` (type: `boolean`, default: `false`): Show archived ToDos.
+* `marquee.widgets.todo.showBranched` (type: `boolean`, default: `false`): Show only ToDos from the same branch.
 * `marquee.widgets.todo.autoDetect` (type: `boolean`, default: `true`): Auto-detect ToDos in your code to allow adding them to Marquee.
 * `marquee.widgets.markdown.externalMarkdownFiles` (type: `string[]`, default: `[]`): Add remote markdown documents to Markdown Widget.
 * `marquee.widgets.npm-stats.packageNames` (type: `string[]`, default: `[]`): NPM package names to display in NPM Stats widget.

--- a/docs/CoreWidgets.md
+++ b/docs/CoreWidgets.md
@@ -61,6 +61,7 @@ Keep track of workspace-specific todos. Create, archive and complete todos from 
 - Attach tags to certain todo so you can easily find them
 - Search for specific todos by their content or tag
 - All todos are visible in the Marquee tree view
+- filter todos by git branch
 
 ## Clipboard Widget
 

--- a/package.json
+++ b/package.json
@@ -3308,6 +3308,12 @@
             "default": false,
             "markdownDescription": "Show archived ToDos"
           },
+          "marquee.widgets.todo.showBranched": {
+            "type": "boolean",
+            "scope": "window",
+            "default": false,
+            "markdownDescription": "Show only ToDos from the same branch"
+          },
           "marquee.widgets.todo.autoDetect": {
             "type": "boolean",
             "scope": "window",

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import vscode from 'vscode'
 import path from 'path'
-import { WorkspaceType, GitProvider } from '@vscode-marquee/utils/extension'
+import { WorkspaceType } from '@vscode-marquee/utils/extension'
 import type { MarqueeEvents } from '@vscode-marquee/utils'
 import type { Snippet } from '@vscode-marquee/widget-snippets/extension'
 
@@ -22,10 +22,7 @@ export class MarqueeExtension {
   private readonly view: vscode.TreeView<any>
   private readonly treeView: TreeView
 
-  constructor (
-    private readonly context: vscode.ExtensionContext,
-    private readonly gitProvider: GitProvider
-  ) {
+  constructor (private readonly context: vscode.ExtensionContext) {
     this.context.subscriptions.push(...this.setupCommands())
 
     this._stateMgr = new StateManager(this.context, this._channel)

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -11,7 +11,7 @@ export async function activate (context: vscode.ExtensionContext) {
   await gitProvider.init()
   context.subscriptions.push(gitProvider)
 
-  new MarqueeExtension(context, gitProvider)
+  new MarqueeExtension(context)
 
   if (process.env.NODE_ENV !== 'development') {
     return {}

--- a/packages/extension/src/index.ts
+++ b/packages/extension/src/index.ts
@@ -3,11 +3,15 @@ import type { Client } from 'tangle'
 
 import telemetry from './telemetry'
 import { MarqueeExtension } from './extension'
-import { getExtProps } from '@vscode-marquee/utils/extension'
+import { getExtProps, GitProvider } from '@vscode-marquee/utils/extension'
 
-export function activate (context: vscode.ExtensionContext) {
+export async function activate (context: vscode.ExtensionContext) {
   telemetry.sendTelemetryEvent('extensionActivate', getExtProps())
-  new MarqueeExtension(context)
+  const gitProvider = new GitProvider(context)
+  await gitProvider.init()
+  context.subscriptions.push(gitProvider)
+
+  new MarqueeExtension(context, gitProvider)
 
   if (process.env.NODE_ENV !== 'development') {
     return {}

--- a/packages/extension/src/tree.view.ts
+++ b/packages/extension/src/tree.view.ts
@@ -73,7 +73,14 @@ export class TreeView implements vscode.TreeDataProvider<Item> {
       return
     }
 
-    this.state.todos = filterByScope(todos, aws, globalScope)
+    this.state.todos = filterByScope(todos, aws, globalScope).filter((todo) => {
+      const worksapceId = aws?.id || ''
+      const branch = this.stateMgr.todoWidget.gitProvider.getBranch()
+      if (!branch || !todo.branch) {
+        return true
+      }
+      return `${worksapceId}#${branch}` === todo.branch
+    })
 
     const openArr: Todo[] = []
     const closedArr: Todo[] = []
@@ -161,7 +168,7 @@ export class TreeView implements vscode.TreeDataProvider<Item> {
         TodoItem.map(this.state.todos || [], this.context.extensionUri)
       )
     }
-    
+
     if (element.type.indexOf('snippets') !== -1) {
       return Promise.resolve(
         SnippetItem.map(this.state.snippets || [], this.context.extensionUri)

--- a/packages/extension/tests/__mocks__/vscode.ts
+++ b/packages/extension/tests/__mocks__/vscode.ts
@@ -49,6 +49,7 @@ vscode.EventEmitter = jest.fn()
 vscode.workspace = {
   name: 'foobarWorkspace',
   workspaceFile: { path: '/foo/bar' },
+  workspaceFolders: [{ uri: '/some/uri' }],
   getConfiguration: jest.fn().mockReturnValue({ get: jest.fn(), update: jest.fn() }),
   onDidCloseTextDocument: jest.fn(),
   onDidChangeTextDocument: jest.fn(),
@@ -62,9 +63,35 @@ vscode.workspace = {
   }),
   lineAtMock,
   registerTextDocumentContentProvider: jest.fn(),
-  registerFileSystemProvider: jest.fn()
+  registerFileSystemProvider: jest.fn(),
+  asRelativePath: jest.fn().mockReturnValue('/some/path')
 }
 vscode.extensions = {
+  getExtension: jest.fn().mockReturnValue({
+    activate: jest.fn().mockResolvedValue({
+      getAPI: jest.fn().mockReturnValue({
+        getRepository: jest.fn().mockReturnValue({
+          log: jest.fn().mockReturnValue([{ hash: 'some hash' }]),
+          state: {
+            onDidChange: jest.fn(),
+            HEAD: {
+              name: 'some name',
+              upstream: {
+                remote: 'origin'
+              }
+            },
+            remotes: [{
+              name: 'origin',
+              fetchUrl: 'git@github.com:stateful/vscode-marquee.git'
+            }, {
+              name: 'lorenzejay',
+              fetchUrl: 'git@github.com:lorenzejay/vscode-marquee.git'
+            }]
+          }
+        })
+      })
+    })
+  }),
   all: []
 }
 vscode.window = {

--- a/packages/extension/tests/index.test.ts
+++ b/packages/extension/tests/index.test.ts
@@ -9,21 +9,25 @@ jest.mock('../src/extension.ts', () => ({
 
 jest.mock('@vscode-marquee/utils/extension', () => ({
   getExtProps: jest.fn().mockReturnValue({ some: 'props' }),
-  pkg: { version: '1.2.3' }
+  pkg: { version: '1.2.3' },
+  GitProvider: class {
+    init = jest.fn()
+  }
 }))
 
 jest.useFakeTimers()
+const context: any = { subscriptions: [] }
 
 test('should activate extension manager', async () => {
   jest.clearAllTimers()
 
-  let exp = activate('context' as any)
+  let exp = await activate(context)
   expect(sendTelemetryEvent).toBeCalledWith('extensionActivate', expect.any(Object), undefined)
 
   expect(typeof exp.marquee).toBe('undefined')
 
   process.env.NODE_ENV = 'development'
-  exp = activate('context' as any)
+  exp = await activate(context)
   const client = { whenReady: jest.fn().mockResolvedValue({}), emit: jest.fn() }
   await exp.marquee!.setup(client as any)
 

--- a/packages/extension/tests/tree.view.test.ts
+++ b/packages/extension/tests/tree.view.test.ts
@@ -2,7 +2,7 @@ import { TreeView } from '../src/tree.view'
 
 const context = {} as any
 const stateMgr = {
-  todoWidget: { on: jest.fn () },
+  todoWidget: { on: jest.fn (), gitProvider: { getBranch: jest.fn() } },
   snippetsWidget: { on: jest.fn () },
   notesWidget: { on: jest.fn () },
   global: { on: jest.fn (), updateState: jest.fn(), state: { globalScope: true } },

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4, v5 as uuidv5 } from 'uuid'
 import { Client } from 'tangle'
 import { EventEmitter } from 'events'
 
-import GitProvider from './provider/git'
+import { GitProvider } from './provider/git'
 import { DEFAULT_CONFIGURATION, DEFAULT_STATE, DEPRECATED_GLOBAL_STORE_KEY, EXTENSION_ID, pkg } from './constants'
 import { WorkspaceType } from './types'
 import type { Configuration, State, Workspace } from './types'
@@ -20,10 +20,10 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
   protected _tangle?: Client<State & Configuration>
   protected _state: State
   protected _configuration: Configuration
-  protected _gitProvider: GitProvider
   protected _disposables: vscode.Disposable[] = [
     vscode.workspace.onDidChangeConfiguration(this._onConfigChange.bind(this))
   ]
+  protected _gitProvider: GitProvider
   protected _subscriptions: { unsubscribe: Function }[] = []
   private _isConfigUpdateListenerDisabled = false
   private _isImportInProgress = false
@@ -36,8 +36,7 @@ export default class ExtensionManager<State, Configuration> extends EventEmitter
     private _defaultState: State
   ) {
     super()
-    this._gitProvider = new GitProvider(this._context)
-    this._disposables.push(this._gitProvider)
+    this._gitProvider = this._context.subscriptions.find((s) => s instanceof GitProvider) as GitProvider
     const config = vscode.workspace.getConfiguration('marquee')
 
     const oldGlobalStore = this._context.globalState.get<object>(DEPRECATED_GLOBAL_STORE_KEY, {})
@@ -385,3 +384,4 @@ export function getExtProps () {
  */
 export * from './types'
 export * from './constants'
+export * from './provider/git'

--- a/packages/utils/src/extension.ts
+++ b/packages/utils/src/extension.ts
@@ -297,7 +297,7 @@ export class GlobalExtensionManager extends ExtensionManager<State, Configuratio
   constructor (...args: any[]) {
     // @ts-expect-error
     super(...args)
-    this._gitProvider.on('stateUpdate', (provider) => {
+    this._gitProvider?.on('stateUpdate', (provider) => {
       this.updateState('branch', provider.branch, true)
       this.updateState('commit', provider.commit, true)
     })

--- a/packages/utils/src/provider/git.ts
+++ b/packages/utils/src/provider/git.ts
@@ -1,0 +1,86 @@
+import vscode from 'vscode'
+import { EventEmitter } from 'events'
+import { API, GitExtension } from '../types/git'
+
+export default class GitProvider extends EventEmitter implements vscode.Disposable {
+  #git?: API
+  #disposables: vscode.Disposable[] = []
+  #branch?: string
+  #commit?: string
+
+  constructor (protected _context: vscode.ExtensionContext) {
+    super()
+
+    if (this.path) {
+      this.#init()
+    }
+  }
+
+  get path () {
+    if (!vscode.workspace.workspaceFolders) {
+      return
+    }
+    return vscode.workspace.workspaceFolders[0].uri
+  }
+
+  get repo () {
+    return this.path ? this.#git?.getRepository(this.path) : undefined
+  }
+
+  get branch () {
+    return this.#branch
+  }
+
+  get commit () {
+    return this.#commit
+  }
+
+  async #init () {
+    console.log('[GitProvider] initiate git extension')
+    const vscodeGit = vscode.extensions.getExtension('vscode.git') as vscode.Extension<GitExtension>
+
+    if (!vscodeGit) {
+      console.error('Failed to load git extension.')
+      return
+    }
+
+    const ext = await vscodeGit.activate()
+    this.#git = ext.getAPI(1)
+    this.repo?.state.onDidChange(this.#updateState.bind(this))
+  }
+
+  async #updateState () {
+    this.#branch = this.getBranch()
+    this.#commit = await this.getCommit()
+    this.emit('stateUpdate', this)
+  }
+
+  getBranch () {
+    if (!this.#git) {
+      return
+    }
+
+    return this.repo?.state.HEAD?.name
+  }
+
+  async getCommit () {
+    if (!this.#git) {
+      return
+    }
+
+    const log = await this.repo?.log({
+      maxEntries: 1,
+      path: vscode.workspace.asRelativePath(this.path!, false)
+    })
+
+    if (!log || log?.length === 0) {
+      return
+    }
+
+    return log[0].hash
+  }
+
+  dispose () {
+    this.#disposables.forEach((d) => d.dispose())
+  }
+}

--- a/packages/utils/src/provider/git.ts
+++ b/packages/utils/src/provider/git.ts
@@ -139,8 +139,9 @@ export class GitProvider extends EventEmitter implements vscode.Disposable {
       if (b.name === 'origin') {
         return 1
       }
-      const aIncludeGithub = vscode.Uri.parse(a.fetchUrl || a.pushUrl || '').authority.endsWith('github.com')
-      const bIncludeGithub = vscode.Uri.parse(b.fetchUrl || b.pushUrl || '').authority.endsWith('github.com')
+
+      const aIncludeGithub = (a.fetchUrl || a.pushUrl || '').startsWith('git@github.com')
+      const bIncludeGithub = (b.fetchUrl || b.pushUrl || '').startsWith('git@github.com')
       if (aIncludeGithub !== bIncludeGithub) {
         if (aIncludeGithub) {
           return -1

--- a/packages/utils/src/provider/git.ts
+++ b/packages/utils/src/provider/git.ts
@@ -139,8 +139,8 @@ export class GitProvider extends EventEmitter implements vscode.Disposable {
       if (b.name === 'origin') {
         return 1
       }
-      const aIncludeGithub = (a.fetchUrl || a.pushUrl || '').includes('github.com')
-      const bIncludeGithub = (b.fetchUrl || b.pushUrl || '').includes('github.com')
+      const aIncludeGithub = vscode.Uri.parse(a.fetchUrl || a.pushUrl || '').authority.endsWith('github.com')
+      const bIncludeGithub = vscode.Uri.parse(b.fetchUrl || b.pushUrl || '').authority.endsWith('github.com')
       if (aIncludeGithub !== bIncludeGithub) {
         if (aIncludeGithub) {
           return -1

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -79,7 +79,7 @@ export interface Configuration {
   name: string
 }
 
-export interface State {
+export interface State extends Pick<ProjectItem, 'commit' | 'branch'> {
   globalScope: boolean
 }
 
@@ -89,4 +89,9 @@ export interface GuiState {
 
 export interface Context extends ContextProperties<State & Configuration & GuiState> {
   themeColor: RGBA
+}
+
+export interface ProjectItem {
+  commit?: string
+  branch?: string
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -95,3 +95,8 @@ export interface ProjectItem {
   commit?: string
   branch?: string
 }
+
+export interface GitRemote {
+  name: string;
+  url: string;
+}

--- a/packages/utils/src/types/git.ts
+++ b/packages/utils/src/types/git.ts
@@ -1,0 +1,340 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Uri, Event, Disposable, ProviderResult } from 'vscode'
+export { ProviderResult } from 'vscode'
+
+export interface Git {
+  readonly path: string
+}
+
+export interface InputBox {
+  value: string
+}
+
+export const enum ForcePushMode {
+  Force,
+  ForceWithLease
+}
+
+export const enum RefType {
+  Head,
+  RemoteHead,
+  Tag
+}
+
+export interface Ref {
+  readonly type: RefType
+  readonly name?: string
+  readonly commit?: string
+  readonly remote?: string
+}
+
+export interface UpstreamRef {
+  readonly remote: string
+  readonly name: string
+}
+
+export interface Branch extends Ref {
+  readonly upstream?: UpstreamRef
+  readonly ahead?: number
+  readonly behind?: number
+}
+
+export interface Commit {
+  readonly hash: string
+  readonly message: string
+  readonly parents: string[]
+  readonly authorDate?: Date
+  readonly authorName?: string
+  readonly authorEmail?: string
+  readonly commitDate?: Date
+}
+
+export interface Submodule {
+  readonly name: string
+  readonly path: string
+  readonly url: string
+}
+
+export interface Remote {
+  readonly name: string
+  readonly fetchUrl?: string
+  readonly pushUrl?: string
+  readonly isReadOnly: boolean
+}
+
+export const enum Status {
+  INDEX_MODIFIED,
+  INDEX_ADDED,
+  INDEX_DELETED,
+  INDEX_RENAMED,
+  INDEX_COPIED,
+
+  MODIFIED,
+  DELETED,
+  UNTRACKED,
+  IGNORED,
+  INTENT_TO_ADD,
+
+  ADDED_BY_US,
+  ADDED_BY_THEM,
+  DELETED_BY_US,
+  DELETED_BY_THEM,
+  BOTH_ADDED,
+  BOTH_DELETED,
+  BOTH_MODIFIED
+}
+
+export interface Change {
+
+  /**
+   * Returns either `originalUri` or `renameUri`, depending
+   * on whether this change is a rename change. When
+   * in doubt always use `uri` over the other two alternatives.
+   */
+  readonly uri: Uri
+  readonly originalUri: Uri
+  readonly renameUri: Uri | undefined
+  readonly status: Status
+}
+
+export interface RepositoryState {
+  readonly HEAD: Branch | undefined
+  readonly refs: Ref[]
+  readonly remotes: Remote[]
+  readonly submodules: Submodule[]
+  readonly rebaseCommit: Commit | undefined
+
+  readonly mergeChanges: Change[]
+  readonly indexChanges: Change[]
+  readonly workingTreeChanges: Change[]
+
+  readonly onDidChange: Event<void>
+}
+
+export interface RepositoryUIState {
+  readonly selected: boolean
+  readonly onDidChange: Event<void>
+}
+
+/**
+ * Log options.
+ */
+export interface LogOptions {
+  /** Max number of log entries to retrieve. If not specified, the default is 32. */
+  readonly maxEntries?: number
+  readonly path?: string
+}
+
+export interface CommitOptions {
+  all?: boolean | 'tracked'
+  amend?: boolean
+  signoff?: boolean
+  signCommit?: boolean
+  empty?: boolean
+  noVerify?: boolean
+  requireUserConfig?: boolean
+}
+
+export interface FetchOptions {
+  remote?: string
+  ref?: string
+  all?: boolean
+  prune?: boolean
+  depth?: number
+}
+
+export interface BranchQuery {
+  readonly remote?: boolean
+  readonly pattern?: string
+  readonly count?: number
+  readonly contains?: string
+}
+
+export interface Repository {
+
+  readonly rootUri: Uri
+  readonly inputBox: InputBox
+  readonly state: RepositoryState
+  readonly ui: RepositoryUIState
+
+  getConfigs(): Promise<{ key: string; value: string }[]>
+  getConfig(key: string): Promise<string>
+  setConfig(key: string, value: string): Promise<string>
+  getGlobalConfig(key: string): Promise<string>
+
+  getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }>
+  detectObjectType(object: string): Promise<{ mimetype: string, encoding?: string }>
+  buffer(ref: string, path: string): Promise<Buffer>
+  show(ref: string, path: string): Promise<string>
+  getCommit(ref: string): Promise<Commit>
+
+  clean(paths: string[]): Promise<void>
+
+  apply(patch: string, reverse?: boolean): Promise<void>
+  diff(cached?: boolean): Promise<string>
+  diffWithHEAD(): Promise<Change[]>
+  diffWithHEAD(path: string): Promise<string>
+  diffWith(ref: string): Promise<Change[]>
+  diffWith(ref: string, path: string): Promise<string>
+  diffIndexWithHEAD(): Promise<Change[]>
+  diffIndexWithHEAD(path: string): Promise<string>
+  diffIndexWith(ref: string): Promise<Change[]>
+  diffIndexWith(ref: string, path: string): Promise<string>
+  diffBlobs(object1: string, object2: string): Promise<string>
+  diffBetween(ref1: string, ref2: string): Promise<Change[]>
+  diffBetween(ref1: string, ref2: string, path: string): Promise<string>
+
+  hashObject(data: string): Promise<string>
+
+  createBranch(name: string, checkout: boolean, ref?: string): Promise<void>
+  deleteBranch(name: string, force?: boolean): Promise<void>
+  getBranch(name: string): Promise<Branch>
+  getBranches(query: BranchQuery): Promise<Ref[]>
+  setBranchUpstream(name: string, upstream: string): Promise<void>
+
+  getMergeBase(ref1: string, ref2: string): Promise<string>
+
+  status(): Promise<void>
+  checkout(treeish: string): Promise<void>
+
+  addRemote(name: string, url: string): Promise<void>
+  removeRemote(name: string): Promise<void>
+  renameRemote(name: string, newName: string): Promise<void>
+
+  fetch(options?: FetchOptions): Promise<void>
+  fetch(remote?: string, ref?: string, depth?: number): Promise<void>
+  pull(unshallow?: boolean): Promise<void>
+  push(remoteName?: string, branchName?: string, setUpstream?: boolean, force?: ForcePushMode): Promise<void>
+
+  blame(path: string): Promise<string>
+  log(options?: LogOptions): Promise<Commit[]>
+
+  commit(message: string, opts?: CommitOptions): Promise<void>
+}
+
+export interface RemoteSource {
+  readonly name: string
+  readonly description?: string
+  readonly url: string | string[]
+}
+
+export interface RemoteSourceProvider {
+  readonly name: string
+  readonly icon?: string // codicon name
+  readonly supportsQuery?: boolean
+  getRemoteSources(query?: string): ProviderResult<RemoteSource[]>
+  getBranches?(url: string): ProviderResult<string[]>
+  publishRepository?(repository: Repository): Promise<void>
+}
+
+export interface RemoteSourcePublisher {
+  readonly name: string
+  readonly icon?: string // codicon name
+  publishRepository(repository: Repository): Promise<void>
+}
+
+export interface Credentials {
+  readonly username: string
+  readonly password: string
+}
+
+export interface CredentialsProvider {
+  getCredentials(host: Uri): ProviderResult<Credentials>
+}
+
+export interface PushErrorHandler {
+  handlePushError(
+    repository: Repository,
+    remote: Remote,
+    refspec: string,
+    error: Error & { gitErrorCode: GitErrorCodes }
+  ): Promise<boolean>
+}
+
+export type APIState = 'uninitialized' | 'initialized'
+
+export interface PublishEvent {
+  repository: Repository
+  branch?: string
+}
+
+export interface API {
+  readonly state: APIState
+  readonly onDidChangeState: Event<APIState>
+  readonly onDidPublish: Event<PublishEvent>
+  readonly git: Git
+  readonly repositories: Repository[]
+  readonly onDidOpenRepository: Event<Repository>
+  readonly onDidCloseRepository: Event<Repository>
+
+  toGitUri(uri: Uri, ref: string): Uri
+  getRepository(uri: Uri): Repository | null
+  init(root: Uri): Promise<Repository | null>
+  openRepository(root: Uri): Promise<Repository | null>
+
+  registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable
+  registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable
+  registerCredentialsProvider(provider: CredentialsProvider): Disposable
+  registerPushErrorHandler(handler: PushErrorHandler): Disposable
+}
+
+export interface GitExtension {
+
+  readonly enabled: boolean
+  readonly onDidChangeEnablement: Event<boolean>
+
+  /**
+   * Returns a specific API version.
+   *
+   * Throws error if git extension is disabled. You can listed to the
+   * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
+   * to know when the extension becomes enabled/disabled.
+   *
+   * @param version Version number.
+   * @returns API instance
+   */
+  getAPI(version: 1): API
+}
+
+export const enum GitErrorCodes {
+  BadConfigFile = 'BadConfigFile',
+  AuthenticationFailed = 'AuthenticationFailed',
+  NoUserNameConfigured = 'NoUserNameConfigured',
+  NoUserEmailConfigured = 'NoUserEmailConfigured',
+  NoRemoteRepositorySpecified = 'NoRemoteRepositorySpecified',
+  NotAGitRepository = 'NotAGitRepository',
+  NotAtRepositoryRoot = 'NotAtRepositoryRoot',
+  Conflict = 'Conflict',
+  StashConflict = 'StashConflict',
+  UnmergedChanges = 'UnmergedChanges',
+  PushRejected = 'PushRejected',
+  RemoteConnectionError = 'RemoteConnectionError',
+  DirtyWorkTree = 'DirtyWorkTree',
+  CantOpenResource = 'CantOpenResource',
+  GitNotFound = 'GitNotFound',
+  CantCreatePipe = 'CantCreatePipe',
+  PermissionDenied = 'PermissionDenied',
+  CantAccessRemote = 'CantAccessRemote',
+  RepositoryNotFound = 'RepositoryNotFound',
+  RepositoryIsLocked = 'RepositoryIsLocked',
+  BranchNotFullyMerged = 'BranchNotFullyMerged',
+  NoRemoteReference = 'NoRemoteReference',
+  InvalidBranchName = 'InvalidBranchName',
+  BranchAlreadyExists = 'BranchAlreadyExists',
+  NoLocalChanges = 'NoLocalChanges',
+  NoStashFound = 'NoStashFound',
+  LocalChangesOverwritten = 'LocalChangesOverwritten',
+  NoUpstreamBranch = 'NoUpstreamBranch',
+  IsInSubmodule = 'IsInSubmodule',
+  WrongCase = 'WrongCase',
+  CantLockRef = 'CantLockRef',
+  CantRebaseMultipleBranches = 'CantRebaseMultipleBranches',
+  PatchDoesNotApply = 'PatchDoesNotApply',
+  NoPathFound = 'NoPathFound',
+  UnknownPath = 'UnknownPath',
+}

--- a/packages/utils/tests/__mocks__/@vscode-marquee/utils/extension.ts
+++ b/packages/utils/tests/__mocks__/@vscode-marquee/utils/extension.ts
@@ -49,3 +49,5 @@ export const pkg = actualExport.pkg
 export const defaultConfigurations = actualExport.defaultConfigurations
 export const DEFAULT_STATE = actualExport.DEFAULT_STATE
 export const DEFAULT_CONFIGURATION = actualExport.DEFAULT_CONFIGURATION
+
+export const GitProvider = class {}

--- a/packages/utils/tests/extension.test.ts
+++ b/packages/utils/tests/extension.test.ts
@@ -2,6 +2,7 @@ import vscode from 'vscode'
 import ExtensionManager, { activate, getExtProps } from '../src/extension'
 
 const context = {
+  subscriptions: [],
   globalState: {
     setKeysForSync: jest.fn(),
     get: jest.fn().mockReturnValue({ someRandomConfig: 'foobar' }),

--- a/packages/utils/tests/provider/git.test.ts
+++ b/packages/utils/tests/provider/git.test.ts
@@ -1,0 +1,40 @@
+import { GitProvider } from '../../src/provider/git'
+
+describe('GitProvider', () => {
+  it('can init', async () => {
+    const git = new GitProvider({} as any)
+    git.getBranch = jest.fn().mockReturnValue('some branch')
+    git.getCommit = jest.fn().mockResolvedValue('some commit')
+    git.getGitUri = jest.fn().mockResolvedValue('some git uri')
+
+    await git.init()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(git.branch).toBe('some branch')
+    expect(git.commit).toBe('some commit')
+    expect(git.gitUri).toBe('some git uri')
+  })
+
+  it('can get branch', async () => {
+    const git = new GitProvider({} as any)
+    expect(git.getBranch()).toBe(undefined)
+    await git.init()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(git.getBranch()).toBe('some name')
+  })
+
+  it('can get commit', async () => {
+    const git = new GitProvider({} as any)
+    expect(await git.getCommit()).toBe(undefined)
+    await git.init()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(await git.getCommit()).toBe('some hash')
+  })
+
+  it('can get git uri', async () => {
+    const git = new GitProvider({} as any)
+    expect(await git.getGitUri()).toBe(undefined)
+    await git.init()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    expect(await git.getGitUri()).toBe('git@github.com:stateful/vscode-marquee.git')
+  })
+})

--- a/packages/widget-notes/src/Context.tsx
+++ b/packages/widget-notes/src/Context.tsx
@@ -34,14 +34,15 @@ const NoteProvider = ({ children }: { children: React.ReactElement }) => {
     const globalNotes = notes
     const id = [...Array(8)].map(() => Math.random().toString(36)[2]).join('')
 
+    const workspaceId = window.activeWorkspace?.id || ''
     const newNote = Object.assign({}, note, {
       id,
       commit,
-      branch,
+      branch: `${workspaceId}#${branch}`,
       archived: false,
       createdAt: new Date().getTime(),
       workspaceId: isWorkspaceTodo
-        ? window.activeWorkspace?.id || null
+        ? workspaceId || null
         : null,
     })
 

--- a/packages/widget-notes/src/Context.tsx
+++ b/packages/widget-notes/src/Context.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useState, useEffect } from 'react'
-import { connect, getEventListener, MarqueeWindow, MarqueeEvents } from '@vscode-marquee/utils'
+import React, { createContext, useState, useEffect, useContext } from 'react'
+import { connect, getEventListener, MarqueeWindow, MarqueeEvents, GlobalContext } from '@vscode-marquee/utils'
 
 import AddDialog from './dialogs/AddDialog'
 import EditDialog from './dialogs/EditDialog'
@@ -10,6 +10,7 @@ const NoteContext = createContext<Context>({} as Context)
 const WIDGET_ID = '@vscode-marquee/notes-widget'
 
 const NoteProvider = ({ children }: { children: React.ReactElement }) => {
+  const { commit, branch } = useContext(GlobalContext)
   const eventListener = getEventListener<Events & MarqueeEvents>()
   const widgetState = getEventListener<State>(WIDGET_ID)
   const providerValues = connect<State>(window.marqueeStateConfiguration[WIDGET_ID].state, widgetState)
@@ -34,7 +35,9 @@ const NoteProvider = ({ children }: { children: React.ReactElement }) => {
     const id = [...Array(8)].map(() => Math.random().toString(36)[2]).join('')
 
     const newNote = Object.assign({}, note, {
-      id: id,
+      id,
+      commit,
+      branch,
       archived: false,
       createdAt: new Date().getTime(),
       workspaceId: isWorkspaceTodo

--- a/packages/widget-notes/src/extension.ts
+++ b/packages/widget-notes/src/extension.ts
@@ -37,7 +37,9 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
       id: this.generateId(),
       workspaceId: this.getActiveWorkspace()?.id || null,
       path,
-      origin: path
+      origin: path,
+      branch: this._gitProvider.branch,
+      commit: this._gitProvider.commit
     }
     const newNotes = [note].concat(this.state.notes)
     this.updateState('notes', newNotes)

--- a/packages/widget-notes/src/extension.ts
+++ b/packages/widget-notes/src/extension.ts
@@ -30,15 +30,16 @@ export class NoteExtensionManager extends ExtensionManager<State, {}> {
       return vscode.window.showWarningMessage('Marquee: no text selected')
     }
 
+    const worksapceId = this.getActiveWorkspace()?.id || ''
     const note: Note = {
       title: name,
       body: text,
       text: text,
       id: this.generateId(),
-      workspaceId: this.getActiveWorkspace()?.id || null,
+      workspaceId: worksapceId || null,
       path,
       origin: path,
-      branch: this._gitProvider.branch,
+      branch: `${worksapceId}#${this._gitProvider.branch}`,
       commit: this._gitProvider.commit
     }
     const newNotes = [note].concat(this.state.notes)

--- a/packages/widget-notes/src/types.ts
+++ b/packages/widget-notes/src/types.ts
@@ -1,6 +1,6 @@
-import type { ContextProperties } from '@vscode-marquee/utils'
+import type { ContextProperties, ProjectItem } from '@vscode-marquee/utils'
 
-export interface Note {
+export interface Note extends ProjectItem {
   id: string
   workspaceId: string | null
   title: string

--- a/packages/widget-snippets/src/Context.tsx
+++ b/packages/widget-snippets/src/Context.tsx
@@ -34,14 +34,15 @@ const SnippetProvider = ({ children }: { children: React.ReactElement }) => {
     const globalSnippets = snippets
     const id = [...Array(8)].map(() => Math.random().toString(36)[2]).join('')
 
+    const workspaceId = window.activeWorkspace?.id || ''
     const newSnippet: Partial<Snippet> = Object.assign({}, snippet, {
       id,
       commit,
-      branch,
+      branch: `${workspaceId}#${branch}`,
       archived: false,
       createdAt: new Date().getTime(),
       workspaceId: isWorkspaceTodo
-        ? window.activeWorkspace?.id || null
+        ? workspaceId || null
         : null
     })
 

--- a/packages/widget-snippets/src/Context.tsx
+++ b/packages/widget-snippets/src/Context.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useState, useEffect } from 'react'
-import { connect, getEventListener, MarqueeWindow, MarqueeEvents } from '@vscode-marquee/utils'
+import React, { createContext, useState, useEffect, useContext } from 'react'
+import { connect, getEventListener, MarqueeWindow, MarqueeEvents, GlobalContext } from '@vscode-marquee/utils'
 
 import { WIDGET_ID } from './constants'
 import type { State, Context, Snippet, Events } from './types'
@@ -8,6 +8,7 @@ declare const window: MarqueeWindow
 const SnippetContext = createContext<Context>({} as Context)
 
 const SnippetProvider = ({ children }: { children: React.ReactElement }) => {
+  const { commit, branch } = useContext(GlobalContext)
   const eventListener = getEventListener<Events & MarqueeEvents>()
   const widgetEvents = getEventListener<Events>(WIDGET_ID)
   const widgetState = getEventListener<State>(WIDGET_ID)
@@ -35,6 +36,8 @@ const SnippetProvider = ({ children }: { children: React.ReactElement }) => {
 
     const newSnippet: Partial<Snippet> = Object.assign({}, snippet, {
       id,
+      commit,
+      branch,
       archived: false,
       createdAt: new Date().getTime(),
       workspaceId: isWorkspaceTodo

--- a/packages/widget-snippets/src/extension.ts
+++ b/packages/widget-snippets/src/extension.ts
@@ -83,6 +83,7 @@ export class SnippetExtensionManager extends ExtensionManager<State, {}> {
       return vscode.window.showWarningMessage('Marquee: no text selected')
     }
 
+    const worksapceId = this.getActiveWorkspace()?.id || ''
     const id = this.generateId()
     const snippet = new Snippet(
       this.getActiveWorkspace()?.id || null,
@@ -91,7 +92,7 @@ export class SnippetExtensionManager extends ExtensionManager<State, {}> {
       false,
       Date.now(),
       id,
-      this._gitProvider.branch,
+      `${worksapceId}#${this._gitProvider.branch}`,
       this._gitProvider.commit,
       path
     )

--- a/packages/widget-snippets/src/extension.ts
+++ b/packages/widget-snippets/src/extension.ts
@@ -91,6 +91,8 @@ export class SnippetExtensionManager extends ExtensionManager<State, {}> {
       false,
       Date.now(),
       id,
+      this._gitProvider.branch,
+      this._gitProvider.commit,
       path
     )
     const newSnippets = [snippet].concat(this.state.snippets)

--- a/packages/widget-snippets/src/models/Snippet.ts
+++ b/packages/widget-snippets/src/models/Snippet.ts
@@ -17,6 +17,8 @@ export default class Snippet implements vscode.FileStat {
     public archived = false,
     public createdAt = Date.now(),
     public id = uuidv4(),
+    public branch?: string,
+    public commit?: string,
     snippetPath?: string
   ) {
     this.type = vscode.FileType.File

--- a/packages/widget-snippets/tests/__snapshots__/extension.test.ts.snap
+++ b/packages/widget-snippets/tests/__snapshots__/extension.test.ts.snap
@@ -8,6 +8,8 @@ Array [
       Snippet {
         "archived": false,
         "body": "foobar",
+        "branch": "#foobar",
+        "commit": undefined,
         "createdAt": 1577836800000,
         "ctime": 1577836800000,
         "id": "123457890",
@@ -35,6 +37,8 @@ Array [
         Snippet {
           "archived": false,
           "body": "foobar",
+          "branch": "#foobar",
+          "commit": undefined,
           "createdAt": 1577836800000,
           "ctime": 1577836800000,
           "id": "123457890",

--- a/packages/widget-snippets/tests/extension.test.ts
+++ b/packages/widget-snippets/tests/extension.test.ts
@@ -56,7 +56,8 @@ test('_openSnippet', async () => {
 })
 
 test('_addSnippet', () => {
-  const m = new SnippetExtensionManager({} as any, {} as any);
+  const m = new SnippetExtensionManager({} as any, {} as any)
+  m['_gitProvider'] = { branch: 'foobar' } as any
   (m.getTextSelection as jest.Mock).mockReturnValueOnce({ text: '' })
   m['_addSnippet']({} as any)
   expect(vscode.window.showWarningMessage).toBeCalledWith('Marquee: no text selected');

--- a/packages/widget-snippets/tests/models/__snapshots__/Snippet.test.ts.snap
+++ b/packages/widget-snippets/tests/models/__snapshots__/Snippet.test.ts.snap
@@ -4,6 +4,8 @@ exports[`Snippet can be created from snippet object 1`] = `
 Object {
   "archived": false,
   "body": "some body",
+  "branch": undefined,
+  "commit": undefined,
   "createdAt": 123,
   "ctime": 123,
   "id": "foobar",

--- a/packages/widget-todo/src/Context.tsx
+++ b/packages/widget-todo/src/Context.tsx
@@ -1,5 +1,5 @@
-import React, { createContext, useState, useEffect } from 'react'
-import { connect, getEventListener, MarqueeWindow, MarqueeEvents } from '@vscode-marquee/utils'
+import React, { createContext, useState, useEffect, useContext } from 'react'
+import { connect, getEventListener, MarqueeWindow, MarqueeEvents, GlobalContext } from '@vscode-marquee/utils'
 
 import AddDialog from './dialogs/AddDialog'
 import EditDialog from './dialogs/EditDialog'
@@ -11,6 +11,7 @@ const TodoContext = createContext<Context>({} as Context)
 const WIDGET_ID = '@vscode-marquee/todo-widget'
 
 const TodoProvider = ({ children }: { children: React.ReactElement }) => {
+  const { commit, branch } = useContext(GlobalContext)
   const eventListener = getEventListener<Events & MarqueeEvents>()
   const widgetState = getEventListener<Configuration & State>(WIDGET_ID)
   const providerValues = connect<Configuration & State>({
@@ -24,12 +25,14 @@ const TodoProvider = ({ children }: { children: React.ReactElement }) => {
   let _addTodo = (body: string, tags: string[] = [], isWorkspaceTodo = true) => {
     eventListener.emit('telemetryEvent', { eventName: 'addTodo' })
     const globalTodos: Todo[] = providerValues.todos
-    const randomString = [...Array(8)].map(() => Math.random().toString(36)[2]).join('')
+    const id = [...Array(8)].map(() => Math.random().toString(36)[2]).join('')
     globalTodos.unshift({
       body,
       tags,
+      id,
+      commit,
+      branch,
       checked: false,
-      id: randomString,
       archived: false,
       workspaceId: isWorkspaceTodo && window.activeWorkspace
         ? window.activeWorkspace.id

--- a/packages/widget-todo/src/Context.tsx
+++ b/packages/widget-todo/src/Context.tsx
@@ -26,16 +26,17 @@ const TodoProvider = ({ children }: { children: React.ReactElement }) => {
     eventListener.emit('telemetryEvent', { eventName: 'addTodo' })
     const globalTodos: Todo[] = providerValues.todos
     const id = [...Array(8)].map(() => Math.random().toString(36)[2]).join('')
+    const workspaceId = window.activeWorkspace?.id || ''
     globalTodos.unshift({
       body,
       tags,
       id,
       commit,
-      branch,
+      branch: `${workspaceId}#${branch}`,
       checked: false,
       archived: false,
       workspaceId: isWorkspaceTodo && window.activeWorkspace
-        ? window.activeWorkspace.id
+        ? workspaceId || null
         : null,
     })
     providerValues.setTodos(globalTodos)

--- a/packages/widget-todo/src/Widget.tsx
+++ b/packages/widget-todo/src/Widget.tsx
@@ -27,12 +27,13 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
     setTodos,
     setShowAddDialog,
     showArchived,
+    showBranched,
     todos,
     hide,
     todoFilter,
     setTodoFilter
   } = useContext(TodoContext)
-  const { globalScope, setGlobalScope } = useContext(GlobalContext)
+  const { globalScope, setGlobalScope, branch } = useContext(GlobalContext)
   const [showCloudSyncFeature, setShowCloudSyncFeature] = useState(false)
 
   const _isInterestedInSyncFeature = (interested: boolean) => {
@@ -89,11 +90,11 @@ let Todo = ({ ToggleFullScreen, minimizeNavIcon, fullscreenMode } : MarqueeWidge
   )
 
   const filteredItems = useMemo(() => (
-    filterItems(todos, { globalScope, hide, todoFilter, showArchived })
-  ), [todos, globalScope, hide, todoFilter, showArchived])
+    filterItems(todos, { globalScope, hide, todoFilter, showArchived, showBranched, branch })
+  ), [todos, globalScope, hide, todoFilter, showArchived, branch])
   const todosInGlobalScope = useMemo(() => (
-    filterItems(todos, { globalScope: true, hide, showArchived }).length
-  ), [todos, globalScope, hide, showArchived])
+    filterItems(todos, { globalScope: true, hide, showArchived, showBranched, branch }).length
+  ), [todos, globalScope, hide, showArchived, branch])
 
   return (
     <>

--- a/packages/widget-todo/src/components/Pop.tsx
+++ b/packages/widget-todo/src/components/Pop.tsx
@@ -64,6 +64,32 @@ let ArchivedBox = React.memo(() => {
   )
 })
 
+const BranchedBox = React.memo(() => {
+  const { setShowBranched, showBranched } = useContext(TodoContext)
+
+  return (
+    <Grid
+      container
+      direction="row"
+      spacing={2}
+      justifyContent="space-between"
+      alignItems="center"
+    >
+      <Grid item>Show from same branch</Grid>
+      <Grid item>
+        <Checkbox
+          aria-label="Show branched"
+          color="primary"
+          checked={showBranched}
+          value={showBranched}
+          name="hide"
+          onChange={(e) => setShowBranched(e.target.checked)}
+        />
+      </Grid>
+    </Grid>
+  )
+})
+
 let AutoDetectBox = React.memo(() => {
   const { setAutoDetect, autoDetect } = useContext(TodoContext)
   return (
@@ -140,6 +166,9 @@ let TodoPop = () => {
           </Grid>
           <Grid item>
             <ArchivedBox />
+          </Grid>
+          <Grid>
+            <BranchedBox />
           </Grid>
           <Grid item>&nbsp;</Grid>
           <Grid item>

--- a/packages/widget-todo/src/components/Pop.tsx
+++ b/packages/widget-todo/src/components/Pop.tsx
@@ -9,6 +9,7 @@ import {
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import Tooltip from '@mui/material/Tooltip'
 import { HideWidgetContent } from '@vscode-marquee/widget'
+import { GlobalContext } from '@vscode-marquee/utils'
 
 import TodoContext from '../Context'
 
@@ -124,6 +125,7 @@ let AutoDetectBox = React.memo(() => {
 })
 
 let TodoPop = () => {
+  const {branch} = useContext(GlobalContext)
   const [anchorEl, setAnchorEl] = useState<Element | null>(null)
 
   const handleClick = useCallback((event: React.MouseEvent) => {
@@ -167,9 +169,11 @@ let TodoPop = () => {
           <Grid item>
             <ArchivedBox />
           </Grid>
-          <Grid>
-            <BranchedBox />
-          </Grid>
+          { branch && (
+            <Grid>
+              <BranchedBox />
+            </Grid>
+          )}
           <Grid item>&nbsp;</Grid>
           <Grid item>
             <Divider />

--- a/packages/widget-todo/src/constants.ts
+++ b/packages/widget-todo/src/constants.ts
@@ -8,5 +8,6 @@ export const DEFAULT_CONFIGURATION: Configuration = {
   todoFilter: '',
   hide: false,
   showArchived: false,
+  showBranched: false,
   autoDetect: true
 }

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -45,6 +45,10 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     )
   }
 
+  get gitProvider () {
+    return this._gitProvider
+  }
+
   private _refreshActiveTextEditor (diagnostics: vscode.DiagnosticCollection) {
     if (vscode.window.activeTextEditor) {
       this._refreshDiagnostics(

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -126,15 +126,18 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
     const path = `${vscode.window.activeTextEditor.document.uri.path}:${diagnostic.range.start.line}`
     body = body.replace(TODO, '').trim()
 
+    const worksapceId = this.getActiveWorkspace()?.id
     const todo: Todo = {
       archived: false,
       body: body,
       checked: false,
+      branch: `${worksapceId}#${this._gitProvider.branch}`,
+      commit: this._gitProvider.commit,
       id: this.generateId(),
       tags: [],
       path,
       origin: path,
-      workspaceId: this.getActiveWorkspace()?.id || null,
+      workspaceId: worksapceId || null,
     }
 
     const newTodos = [todo].concat(this.state.todos)

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -188,6 +188,8 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       path: path,
       origin: path,
       workspaceId: this.getActiveWorkspace()?.id || null,
+      branch: this._gitProvider.branch,
+      commit: this._gitProvider.commit
     }
     const newTodos = [todo].concat(this.state.todos)
     this.updateState('todos', newTodos)

--- a/packages/widget-todo/src/types.ts
+++ b/packages/widget-todo/src/types.ts
@@ -1,6 +1,6 @@
-import type { ContextProperties } from '@vscode-marquee/utils'
+import type { ContextProperties, ProjectItem } from '@vscode-marquee/utils'
 
-export interface Todo {
+export interface Todo extends ProjectItem {
   body: string
   checked: boolean
   id: string
@@ -19,6 +19,7 @@ export interface Configuration {
   todoFilter?: string
   hide: boolean
   showArchived: boolean
+  showBranched: boolean
   autoDetect: boolean
 }
 

--- a/packages/widget-todo/src/utils.ts
+++ b/packages/widget-todo/src/utils.ts
@@ -8,6 +8,8 @@ interface FilterParams {
   hide?: boolean
   todoFilter?: string
   showArchived?: boolean
+  showBranched?: boolean
+  branch?: string
 }
 export function filterItems (todos: Todo[], params: FilterParams) {
   let filteredItems = todos
@@ -23,6 +25,15 @@ export function filterItems (todos: Todo[], params: FilterParams) {
   if (!params.showArchived) {
     filteredItems = filteredItems.filter((item) => {
       if (!item.hasOwnProperty('archived') || item.archived === false) {
+        return true
+      }
+    })
+  }
+
+  if (params.showBranched && params.branch) {
+    filteredItems = filteredItems.filter((item) => {
+      console.log('OK FILTER', item.body, item.branch, params.branch)
+      if (!item.hasOwnProperty('branch') || item.branch === params.branch) {
         return true
       }
     })

--- a/packages/widget-todo/src/utils.ts
+++ b/packages/widget-todo/src/utils.ts
@@ -13,6 +13,7 @@ interface FilterParams {
 }
 export function filterItems (todos: Todo[], params: FilterParams) {
   let filteredItems = todos
+  const workspaceId = window.activeWorkspace?.id || ''
 
   if (!params.globalScope) {
     filteredItems = filteredItems.filter((item) => {
@@ -32,8 +33,7 @@ export function filterItems (todos: Todo[], params: FilterParams) {
 
   if (params.showBranched && params.branch) {
     filteredItems = filteredItems.filter((item) => {
-      console.log('OK FILTER', item.body, item.branch, params.branch)
-      if (!item.hasOwnProperty('branch') || item.branch === params.branch) {
+      if (!item.hasOwnProperty('branch') || item.branch === `${workspaceId}#${params.branch}`) {
         return true
       }
     })

--- a/packages/widget-todo/tests/__snapshots__/extension.test.ts.snap
+++ b/packages/widget-todo/tests/__snapshots__/extension.test.ts.snap
@@ -8,7 +8,9 @@ Array [
       Object {
         "archived": false,
         "body": "some new todo here",
+        "branch": "undefined#foobar",
         "checked": false,
+        "commit": "somecommit",
         "id": "123457890",
         "origin": "/some/path.js:123",
         "path": "/some/path.js:123",
@@ -28,7 +30,9 @@ Array [
         Object {
           "archived": false,
           "body": "some new todo here",
+          "branch": "undefined#foobar",
           "checked": false,
+          "commit": "somecommit",
           "id": "123457890",
           "origin": "/some/path.js:123",
           "path": "/some/path.js:123",
@@ -46,6 +50,7 @@ Object {
   "autoDetect": true,
   "hide": false,
   "showArchived": false,
+  "showBranched": false,
   "todoFilter": "",
 }
 `;

--- a/packages/widget-todo/tests/extension.test.ts
+++ b/packages/widget-todo/tests/extension.test.ts
@@ -66,7 +66,10 @@ describe('_addTodo', () => {
       context as any,
       {} as any
     )
-
+    manager['_gitProvider'] = {
+      branch: 'foobar',
+      commit: 'somecommit'
+    } as any
     vscode.window.activeTextEditor = {
       document: {
         getText: jest.fn().mockReturnValue('ToDo: some new todo here'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,6 +2196,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.2.tgz#ffc5f0f099d27887c8d9067b54e55090fcd54126"
   integrity sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==
 
+"@types/node@^18.7.1":
+  version "18.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.1.tgz#352bee64f93117d867d05f7406642a52685cbca6"
+  integrity sha512-GKX1Qnqxo4S+Z/+Z8KKPLpH282LD7jLHWJcVryOflnsnH+BtSDfieR6ObwBMwpnNws0bUK8GI7z0unQf9bARNQ==
+
 "@types/object-hash@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-2.2.1.tgz#67c169f8f033e0b62abbf81df2d00f4598d540b9"
@@ -2240,12 +2245,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@17.0.16", "@types/react-dom@^18.0.0":
-  version "17.0.16"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.16.tgz#7caba93cf2806c51e64d620d8dff4bae57e06cc4"
-  integrity sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==
+"@types/react-dom@^18.0.0":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
   dependencies:
-    "@types/react" "^17"
+    "@types/react" "*"
 
 "@types/react-grid-layout@^1.3.2":
   version "1.3.2"
@@ -2290,7 +2295,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.45", "@types/react@^17":
+"@types/react@*", "@types/react@^17":
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
   integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==


### PR DESCRIPTION
We want to be more smart about in which branch certain items were created to be able to better identify the location of it. This first patch enhances snippets, todos and notes with branch and commit information and allows to filter todos by branch, e.g.:
![branch](https://user-images.githubusercontent.com/731337/184372379-d4611aca-e2d4-4f06-86b3-9b8855504209.gif)

