### PR TITLE
[🐛 Bug]: Correcting VS Code spelling from VSCode on website 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,13 +5,13 @@ labels: [Bug 🐛, Needs Triaging ⏳]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this bug report! First, let's get some information about the VSCode environment you are using. For that please open VSCode and open the `Code` menu and go to `About Visual Studio Code`.
+      value: Thanks for taking the time to fill out this bug report! First, let's get some information about the VS Code environment you are using. For that please open VS Code and open the `Code` menu and go to `About Visual Studio Code`.
 
   - type: textarea
     id: environment
     attributes:
-      label: VSCode Environment
-      description: Information about the VSCode environment you are using.
+      label: VS Code Environment
+      description: Information about the VS Code environment you are using.
       placeholder: |
         Version: 1.63.2 (Universal)
         Commit: 899d46d82c4c95423fb7e10e68eba52050e30ba3

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
 
   - type: markdown
     attributes:
-      value: Thanks for taking the time and for sharing your great idea with us. Like many VSCode extensions Marquee is an open source project and lives from these great ideas.
+      value: Thanks for taking the time and for sharing your great idea with us. Like many VS Code extensions Marquee is an open source project and lives from these great ideas.
 
   - type: textarea
     id: problem

--- a/.github/scripts/updateEdgeVersion.js
+++ b/.github/scripts/updateEdgeVersion.js
@@ -14,7 +14,7 @@ const pkg = JSON.parse(fs.readFileSync(pkgPath).toString());
 const newVersion = pkg.version.split('.').slice(0, 2)
 
 /**
- * VSCode Marketplace version requirements:
+ * VS Code Marketplace version requirements:
  * It must be one to four numbers in the range 0 to 2147483647,
  * with each number seperated by a period. It must contain at least one non-zero number.
  */

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Next, build the project:
 yarn build:dev
 ```
 
-and open up VSCode:
+and open up VS Code:
 
 ```sh
 code .

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This extension contributes the following settings:
 
 * `marquee.configuration.proxy` (type: `string`, default: `""`): URL to proxy (e.g. `https://username:password@domain.tld:port`). __Note:__ This only has an effect on widgets that gather data from the extension host (e.g. Welcome Widget).
 * `marquee.configuration.fontSize` (type: `number`, default: `5`): Font Size of Widgets (`0` very small / `10` very large).
-* `marquee.configuration.colorScheme` (type: `object`, default: `{}`): The color scheme applied to the Marquee Webview (default is based on the current VSCode color scheme).
+* `marquee.configuration.colorScheme` (type: `object`, default: `{}`): The color scheme applied to the Marquee Webview (default is based on the current VS Code color scheme).
 * `marquee.configuration.name` (type: `string`, default: `name here...`): Your name so Marquee can greet you!
 * `marquee.configuration.background` (type: `string`, default: `1`): Homescreen background image (currently only numbers between 1-10 are available, we will add support for Unsplash images soon).
 * `marquee.configuration.modes` (type: `object`): Configuration of your widget location and display.

--- a/docs/CoreWidgets.md
+++ b/docs/CoreWidgets.md
@@ -4,7 +4,7 @@ Marquee currently supports a broad set of widgets that help you build your own c
 
 ## Mailbox Widget
 
-The Mailbox widget is a communication channel between the extension developers and users of Marquee. You will find announcement as well as tipps and tricks around VSCode and Marquee.
+The Mailbox widget is a communication channel between the extension developers and users of Marquee. You will find announcement as well as tipps and tricks around VS Code and Marquee.
 
 <img src="https://marquee-seven.vercel.app/assets/widgets/mailbox.png" alt="Mailbox Widget" width="600" />
 
@@ -72,7 +72,7 @@ The inter-workspace smart clipboard for your thoughts, code snippets, logs, or t
 ### Features
 
 - Support for code highlighting
-- Allows to create clipboards directly out of VSCode text files
+- Allows to create clipboards directly out of VS Code text files
 - Easily paste a snippet into a document through the `Insert from Clipboard Item` command
 - Clipboards can also be access from the Marquee tree view
 

--- a/docs/CustomWidgets.md
+++ b/docs/CustomWidgets.md
@@ -1,6 +1,6 @@
 # Custom Widgets
 
-Do you want to build your own custom widget? You can do that! Just build your own VSCode extension using the [offical VSCode documentation](https://code.visualstudio.com/api/get-started/your-first-extension) with some Marquee specific settings.
+Do you want to build your own custom widget? You can do that! Just build your own VS Code extension using the [offical VS Code documentation](https://code.visualstudio.com/api/get-started/your-first-extension) with some Marquee specific settings.
 
 ## Widget Architecture
 
@@ -29,7 +29,7 @@ To add your widget to Marquee add the following to your extension:
   ```
 
   You can define as many widgets as you like.
-- Publish your VSCode extension to the marketplace, and voilá - once you install the extension, Marquee will automatically pick it up and display its content
+- Publish your VS Code extension to the marketplace, and voilá - once you install the extension, Marquee will automatically pick it up and display its content
 
 ## Data Communication
 
@@ -100,4 +100,4 @@ class MyAwesomeWidget extends HTMLElement {
 }
 ```
 
-Note that the channel name you want to attach to is your extension id. Also important: Marquee attaches the VSCodeWebview instance, that you usually acquire through `window.acquireVsCodeApi()`, to the `window` scope for you to use.
+Note that the channel name you want to attach to is your extension id. Also important: Marquee attaches the VS CodeWebview instance, that you usually acquire through `window.acquireVsCodeApi()`, to the `window` scope for you to use.

--- a/package.json
+++ b/package.json
@@ -427,7 +427,7 @@
               }
             },
             "additionalProperties": false,
-            "description": "The color scheme applied to the Marquee Webview (default is based on the current VSCode color scheme)"
+            "description": "The color scheme applied to the Marquee Webview (default is based on the current VS Code color scheme)"
           },
           "marquee.configuration.name": {
             "type": "string",

--- a/packages/extension/src/gui.view.ts
+++ b/packages/extension/src/gui.view.ts
@@ -125,7 +125,7 @@ export class MarqueeGui extends EventEmitter {
     const fontSize = 0.5 + ((typeof pref?.fontSize === 'number' ? pref.fontSize : DEFAULT_FONT_SIZE) / 10)
     const widgets = [
       /**
-       * 3rd party VSCode extension widgets
+       * 3rd party VS Code extension widgets
        */
       ...vscode.extensions.all,
       /**

--- a/packages/extension/src/utils.ts
+++ b/packages/extension/src/utils.ts
@@ -55,7 +55,7 @@ export class GUIExtensionManager extends ExtensionManager<State, Configuration> 
     /**
      * when updating modes the webview passes the native ascii icon (e.g. "💼") which
      * breaks when sending from webview to extension host. This ensures that we don't
-     * includes these broken ascii characters into the VSCode settings file
+     * includes these broken ascii characters into the VS Code settings file
      */
     if (prop === 'modes') {
       this._lastModesChange = Date.now()

--- a/packages/gui/tests/dialogs/SettingsDialog.test.tsx
+++ b/packages/gui/tests/dialogs/SettingsDialog.test.tsx
@@ -46,7 +46,7 @@ test('switches to import/export settings', async () => {
   expect(close).toBeCalledTimes(2)
 })
 
-test('should open Marquee settings in VSCode preference view', async () => {
+test('should open Marquee settings in VS Code preference view', async () => {
   window.vscode = { postMessage: jest.fn() }
 
   const close = jest.fn()

--- a/packages/widget-npm-stats/src/extension.ts
+++ b/packages/widget-npm-stats/src/extension.ts
@@ -27,7 +27,7 @@ export class NPMStatsExtensionManager extends ExtensionManager<State, Configurat
        */
       !vscode.workspace.workspaceFolders ||
       /**
-       * there are custom packages defined the VSCode configuration
+       * there are custom packages defined the VS Code configuration
        */
       this._configuration.packageNames.length !== 0
     ) {

--- a/packages/widget-projects/src/extension.ts
+++ b/packages/widget-projects/src/extension.ts
@@ -33,7 +33,7 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
       !this._state.workspaces.find((ws: any) => ws.id === aws.id) &&
       /**
        * we are not running on a remote machine, this is necessary
-       * because we aren't able to connect to remote VSCode instances
+       * because we aren't able to connect to remote VS Code instances
        * through `vscode.openFolder`
        * see more: https://github.com/microsoft/vscode-remote-release/issues/6243
        */

--- a/packages/widget-projects/src/index.tsx
+++ b/packages/widget-projects/src/index.tsx
@@ -9,7 +9,7 @@ export default {
   icon: <FontAwesomeIcon icon={faProjectDiagram} />,
   tags: ['workspace', 'organize', 'productivity'],
   label: 'Projects',
-  description: 'Search and access VSCode project folders and workspaces.',
+  description: 'Search and access VS Code project folders and workspaces.',
   component: Projects,
 }
 export { Projects }

--- a/packages/widget-projects/tests/__mocks__/@vscode-marquee/widget-projects.tsx
+++ b/packages/widget-projects/tests/__mocks__/@vscode-marquee/widget-projects.tsx
@@ -4,6 +4,6 @@ export default {
   name: 'projects',
   icon: <div>Projects Icon</div>,
   tags: ['workspace', 'organize', 'productivity'],
-  description: 'Search and access VSCode project folders and workspaces.',
+  description: 'Search and access VS Code project folders and workspaces.',
   component: () => <div>Projects Widget</div>,
 }

--- a/packages/widget-snippets/src/provider/SnippetStorageProvider.ts
+++ b/packages/widget-snippets/src/provider/SnippetStorageProvider.ts
@@ -75,7 +75,7 @@ export default class SnippetStorageProvider extends EventEmitter implements vsco
       )
 
       /**
-       * emit with delay so that VSCode can store the file and no prompt appears
+       * emit with delay so that VS Code can store the file and no prompt appears
        */
       setTimeout(() => this.emit('saveNewSnippet', snippet), 100)
       this._channel.appendLine(


### PR DESCRIPTION
### VSCode Environment

persists on - https://marquee.stateful.com/

### Marquee Version

v3.2.1659813370

### Workspace Type

Local Workspace

### What happened?

Adjusting to the correct way of displaying `VS Code` instead of the current `VSCode` across the website.

### What is your expected behavior?

VS Code instead of VSCode

### Relevant Log Output

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct

### Is there an existing issue for this?

- [X] I have searched the existing issues