### PR TITLE
Use our own hnrss service

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "theme": "light"
   },
   "badges": [
-		{
-			"url": "https://img.shields.io/badge/Marquee-Join%20our%20Community-blue?logo=discord&color=F62459",
-			"href": "https://discord.gg/BQm8zRCBUY",
-			"description": "Join us on Discord"
-		}
-	],
+    {
+      "url": "https://img.shields.io/badge/Marquee-Join%20our%20Community-blue?logo=discord&color=F62459",
+      "href": "https://discord.gg/BQm8zRCBUY",
+      "description": "Join us on Discord"
+    }
+  ],
   "categories": [
     "Snippets",
     "Debuggers",
@@ -2559,11 +2559,11 @@
               "type": "string"
             },
             "default": {
-              "HN Newest": "https://hnrss.org/newest",
-              "HN Ask": "https://hnrss.org/ask",
-              "HN Show": "https://hnrss.org/show",
-              "HN Jobs": "https://hnrss.org/jobs",
-              "HN Best": "https://hnrss.org/best"
+              "HN Newest": "https://hnrss.stateful.com/newest",
+              "HN Ask": "https://hnrss.stateful.com/ask",
+              "HN Show": "https://hnrss.stateful.com/show",
+              "HN Jobs": "https://hnrss.stateful.com/jobs",
+              "HN Best": "https://hnrss.stateful.com/best"
             },
             "scope": "window",
             "markdownDescription": "Define your news feed channels by providing a feed label (Item) and url (Value)"

--- a/packages/widget-news/src/constants.ts
+++ b/packages/widget-news/src/constants.ts
@@ -1,6 +1,5 @@
 import { State, Configuration } from './types'
 
-export const HN_RSS_HOSTNAME = 'hnrss.org'
 export const MIN_UPDATE_INTERVAL = 1000 * 60
 export const FETCH_DATA_TIMEOUT = 10000
 export const DEFAULT_STATE: State = {

--- a/packages/widget-news/src/extension.ts
+++ b/packages/widget-news/src/extension.ts
@@ -2,7 +2,7 @@ import vscode from 'vscode'
 import Parser from 'rss-parser'
 import ExtensionManager from '@vscode-marquee/utils/extension'
 
-import { DEFAULT_CONFIGURATION, DEFAULT_STATE, MIN_UPDATE_INTERVAL, HN_RSS_HOSTNAME } from './constants'
+import { DEFAULT_CONFIGURATION, DEFAULT_STATE, MIN_UPDATE_INTERVAL } from './constants'
 import type { Configuration, FeedItem, State } from './types'
 
 const STATE_KEY = 'widgets.news'
@@ -44,14 +44,6 @@ export class NewsExtensionManager extends ExtensionManager<State, Configuration>
       }
 
       this._channel.appendLine(`Fetch News ("${this._state.channel}") from ${url}`)
-
-      /**
-       * ensure we don't run into rate limit issue by adding a timestamp to the url
-       * in case we request hnrss feeds
-       */
-      if (vscode.Uri.parse(url).authority === HN_RSS_HOSTNAME) {
-        url += `?${Date.now()}`
-      }
       const feed = await this._parser.parseURL(url)
 
       await this.updateState('news', feed.items as FeedItem[])


### PR DESCRIPTION
Given that https://hnrss.org/ has proven to be not very reliable for us we created our own service to fetch HN rss feeds. This patch updates the url to that respective service.