### PR TITLE
[💡 Feature]: Allow to better return to Marquee when changing themes

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -68,8 +68,9 @@ export class MarqueeExtension {
 
     this.gui.close()
     vscode.window.showInformationMessage(
-      'Please reload your Marquee View to apply the new theme.'
-    )
+      'Please reload your Marquee View to apply the new theme.',
+      'Open Marquee'
+    ).then((item) => item && this.gui.open())
   }
 
   /**

--- a/packages/extension/tests/extension.test.ts
+++ b/packages/extension/tests/extension.test.ts
@@ -169,3 +169,20 @@ test('_editTreeItem', async () => {
     `parsedUri-snippet:${filePath}`)
   expect(vscode.window.showTextDocument).toBeCalledTimes(2)
 })
+
+test('_onColorThemeChange', () => {
+  const context: any = { subscriptions: [], extensionPath: '/foo/bar' }
+  const ext = new MarqueeExtension(context)
+  // @ts-expect-error
+  ext['gui'] = {
+    isActive: jest.fn(),
+    close: jest.fn(),
+    open: jest.fn()
+  }
+  ext['_onColorThemeChange']()
+  expect(ext['gui'].close).toBeCalledTimes(0)
+
+  ;(ext['gui'].isActive as jest.Mock).mockReturnValue(true)
+  ext['_onColorThemeChange']()
+  expect(vscode.window.showInformationMessage).toBeCalledTimes(1)
+})


### PR DESCRIPTION
### Is your feature request related to a problem?

When a user changes the theme VS Code automatically closes all webviews for some reason. At the moment we just send a notification to tell the user to re-open Marquee but we could make this easier.

### Describe the solution you'd like.

Provide a button in that notification with an immediate link back to the webview.

Demo:

![demo-button](https://user-images.githubusercontent.com/731337/188678989-3ed17560-be31-4dac-8e84-b7c5166f049a.gif)

### Describe alternatives you've considered.

n/a

### Additional context

The reason we have to close the UI is because VS Code doesn't automatically apply the CSS changes to the webview causing the webview to look the same as before.

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct