### PR TITLE
State Management Refactoring

### DIFF
--- a/packages/utils/src/state/manager.ts
+++ b/packages/utils/src/state/manager.ts
@@ -1,0 +1,60 @@
+import { Disposable, ExtensionContext } from 'vscode'
+
+import provider from './provider'
+import { VSCodeState } from './provider/vscode'
+import { Logger } from '../logger'
+import type { StateProvider } from './types'
+
+export class StateManager<State> implements Disposable {
+  #state?: State
+  #logger: Logger
+  #context: ExtensionContext
+  #provider: StateProvider<State>[] = []
+
+  constructor (context: ExtensionContext, key: string, defaultState: State) {
+    this.#logger = Logger.getChildLogger('StateManager')
+    this.#context = context
+    this.#provider.push(
+      /**
+       * always
+       */
+      new VSCodeState(this.#context, key, defaultState),
+      ...(this.#context.workspaceState.get<string[]>('stateProvider') || [])
+        .filter((p) => Boolean(provider[p]))
+        .map((p) => new provider[p](context, key, defaultState))
+    )
+  }
+
+  get state (): State  {
+    if (!this.state) {
+      throw new Error('StateManager is not in sync')
+    }
+
+    return this.state
+  }
+
+  async updateState <T extends keyof State = keyof State>(prop: T, val: State[T]) {
+    for (const provider of this.#provider) {
+      await provider.updateState(prop, val)
+    }
+  }
+
+  async clearState () {
+    for (const provider of this.#provider) {
+      await provider.clear()
+    }
+  }
+
+  /**
+   * Downloads current State from providers and merge them if necessary
+   */
+  async sync () {
+    for (const provider of this.#provider) {
+      await provider.sync()
+    }
+  }
+
+  dispose () {
+    // nothing to do
+  }
+}

--- a/packages/utils/src/state/provider/index.ts
+++ b/packages/utils/src/state/provider/index.ts
@@ -1,0 +1,16 @@
+import type { ExtensionContext } from 'vscode'
+
+import { StatefulState } from './stateful'
+import type { StateProvider } from '../types'
+
+type StateProviderClass = new (
+  context: ExtensionContext,
+  key: string,
+  defaultState: any
+) => StateProvider<any>
+
+const provider: Record<string, StateProviderClass> = {
+  stateful: StatefulState
+}
+
+export default provider

--- a/packages/utils/src/state/provider/stateful.ts
+++ b/packages/utils/src/state/provider/stateful.ts
@@ -1,0 +1,25 @@
+import type { ExtensionContext } from 'vscode'
+import type { StateProvider } from '../types'
+
+export class StatefulState<State> implements StateProvider<State> {
+  #state: State = {} as State
+
+  constructor (public context: ExtensionContext) {}
+
+  get state () {
+    return this.#state
+  }
+
+  async updateState (/*key: keyof State, value: State[keyof State]*/): Promise<void> {
+    // throw new Error('Method not implemented.')
+  }
+  getState (): State {
+    throw new Error('Method not implemented.')
+  }
+  sync (): State {
+    throw new Error('Method not implemented.')
+  }
+  clear (): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/packages/utils/src/state/provider/vscode.ts
+++ b/packages/utils/src/state/provider/vscode.ts
@@ -1,0 +1,71 @@
+import pick from 'lodash.pick'
+import hash from 'object-hash'
+import type { ExtensionContext } from 'vscode'
+
+import { Logger } from '../../logger'
+import { DEPRECATED_GLOBAL_STORE_KEY } from '../../constants'
+import type { StateProvider } from '../types'
+
+export class VSCodeState<State> implements StateProvider<State> {
+  #state: State
+
+  constructor (
+    public context: ExtensionContext,
+    private _key: string,
+    private _defaultState: State
+  ) {
+    const oldGlobalStore = this.context.globalState.get<object>(DEPRECATED_GLOBAL_STORE_KEY, {})
+    this.#state = {
+      ...this._defaultState,
+      ...pick(oldGlobalStore, Object.keys(this._defaultState as any)),
+      ...this.context.globalState.get<State>(this._key)
+    }
+
+    /**
+     * preserve state across different machines
+     */
+    this.context.globalState.setKeysForSync(Object.keys(this._defaultState as any))
+  }
+
+  get state () {
+    return this.#state
+  }
+
+  /**
+   * Update extension state
+   * @param prop state property name
+   * @param val new state property value
+   * @param broadcastState set to true if you want to broadcast this state change
+   *                       (only needed when updating state from the extension host)
+   */
+  async updateState <T extends keyof State = keyof State>(prop: T, val: State[T]) {
+    /**
+     * check if we have to update
+     */
+    if (
+      typeof val !== 'undefined' &&
+      typeof this.#state[prop] !== 'undefined' &&
+      hash(this.#state[prop] as any) === hash(val as any)
+    ) {
+      return
+    }
+
+    Logger.info(`Update state "${prop.toString()}": ${val as any as string}`)
+    this.#state[prop] = val
+    await this.context.globalState.update(this._key, this.#state)
+  }
+
+  async clear () {
+    this.#state = { ...this._defaultState }
+    await this.context.globalState.update(this._key, this.#state)
+    await this.context.globalState.update(DEPRECATED_GLOBAL_STORE_KEY, undefined)
+  }
+
+  getState (): State {
+    throw new Error('Method not implemented.')
+  }
+
+  sync (): State {
+    return this.state
+  }
+}

--- a/packages/utils/src/state/types.ts
+++ b/packages/utils/src/state/types.ts
@@ -1,0 +1,27 @@
+import { ExtensionContext } from 'vscode'
+
+export abstract class StateProvider<State> {
+  abstract context: ExtensionContext
+  abstract state: State
+
+  /**
+   * Allows to sync a specific key value pair with provider
+   * @param key state key
+   * @param value state value
+   */
+  abstract updateState (key: keyof State, value: State[keyof State]): Promise<void>
+  /**
+   * Downloads the latest state from the provider and returns it
+   */
+  abstract getState (): State
+  /**
+   * Gets the provider values and compares them with local ones. If a conflict
+   * is detected the value of the environment that was last updated is picked.
+   * ToDo(Christian): make this configurable, e.g. allow to get asked etc.
+   */
+  abstract sync (): State
+  /**
+   * Clears the state of the provider
+   */
+  abstract clear (): Promise<void>
+}

--- a/packages/widget-news/src/extension.ts
+++ b/packages/widget-news/src/extension.ts
@@ -53,16 +53,16 @@ export class NewsExtensionManager extends ExtensionManager<State, Configuration>
     await this.updateState('isFetching', true)
 
     try {
-      let url = this._configuration.feeds[this._state.channel]
+      let url = this._configuration.feeds[this.state.channel]
       if (!url) {
         await this.updateState('channel', Object.keys(this._configuration.feeds)[0], true)
         throw new Error(
-          `Channel "${this._state.channel}" not found, ` +
+          `Channel "${this.state.channel}" not found, ` +
           `available channels are ${Object.keys(this._configuration.feeds).join(', ')}`
         )
       }
 
-      this.#logger.info(`Fetch News ("${this._state.channel}") from ${url}`)
+      this.#logger.info(`Fetch News ("${this.state.channel}") from ${url}`)
       const feed = await this._parser.parseURL(url)
 
       await this.updateState('news', feed.items as FeedItem[])

--- a/packages/widget-projects/src/extension.ts
+++ b/packages/widget-projects/src/extension.ts
@@ -27,7 +27,7 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
       /**
        * the workspace isn't part of the existing list
        */
-      !this._state.workspaces.find((ws: any) => ws.id === aws.id) &&
+      !this.state.workspaces.find((ws: any) => ws.id === aws.id) &&
       /**
        * we are not running on a remote machine, this is necessary
        * because we aren't able to connect to remote VS Code instances
@@ -36,19 +36,19 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
        */
       typeof vscode.env.remoteName === 'undefined'
     ) {
-      this.updateState('workspaces', [...this._state.workspaces, aws])
+      this.updateState('workspaces', [...this.state.workspaces, aws])
     }
 
     /**
      * count workspace usage
      */
     if (aws) {
-      const newWorkspaceVisitCount = this._state.visitCount[aws.id]
-        ? this._state.visitCount[aws.id] + 1
+      const newWorkspaceVisitCount = this.state.visitCount[aws.id]
+        ? this.state.visitCount[aws.id] + 1
         : 1
 
       const visitCount = {
-        ...this._state.visitCount,
+        ...this.state.visitCount,
         [aws.id]: newWorkspaceVisitCount
       }
 
@@ -56,13 +56,13 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
        * remove ids from `visitCount` list that aren't in workspace list (cleanup)
        */
       for (const id of Object.keys(visitCount)) {
-        if (!this._state.workspaces.find((w) => w.id === id)) {
+        if (!this.state.workspaces.find((w) => w.id === id)) {
           delete visitCount[id]
         }
       }
 
       const lastVisited = {
-        ...this._state.lastVisited,
+        ...this.state.lastVisited,
         [aws.id]: Date.now()
       }
 
@@ -70,7 +70,7 @@ export class ProjectsExtensionManager extends ExtensionManager<State, Configurat
        * remove ids from `lastVisited` list that aren't in workspace list (cleanup)
        */
       for (const id of Object.keys(lastVisited)) {
-        if (!this._state.workspaces.find((w) => w.id === id)) {
+        if (!this.state.workspaces.find((w) => w.id === id)) {
           delete lastVisited[id]
         }
       }

--- a/packages/widget-todo/src/extension.ts
+++ b/packages/widget-todo/src/extension.ts
@@ -248,9 +248,9 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       return console.warn(`Couldn't find todo to toggle with id "${item.id}"`)
     }
 
-    this.state.todos[todoIndex].checked = !item.checked
-    this.emitStateUpdate()
-    this.broadcast({ todos: this.state.todos })
+    const todos = [...this.state.todos]
+    todos[todoIndex].checked = !item.checked
+    return this.updateState('todos', todos, true)
   }
 
   /**
@@ -265,9 +265,9 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       return console.warn(`Couldn't find todo to toggle with id "${item.id}"`)
     }
 
-    this.state.todos[todoIndex].archived = !item.archived
-    this.emitStateUpdate()
-    this.broadcast({ todos: this.state.todos })
+    const todos = [...this.state.todos]
+    todos[todoIndex].archived = !item.archived
+    return this.updateState('todos', todos, true)
   }
 
   /**
@@ -288,9 +288,9 @@ export class TodoExtensionManager extends ExtensionManager<State, Configuration>
       return console.warn(`Couldn't find todo to toggle with id "${item.id}"`)
     }
 
-    this.state.todos[todoIndex].workspaceId = awsp.id
-    this.emitStateUpdate()
-    this.broadcast({ todos: this.state.todos })
+    const todos = [...this.state.todos]
+    todos[todoIndex].workspaceId = awsp.id
+    return this.updateState('todos', todos, true)
   }
 }
 


### PR DESCRIPTION
We'ld like to extend Marquee with the ability to receive data from other sources than VS Code, e.g. get notes and other project items from GSuite or Stateful. This requires some refactor to enable this.