### PR TITLE
[💡 Feature]: Add `HN Frontpage` and make it default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2555,6 +2555,7 @@
               "type": "string"
             },
             "default": {
+              "HN Frontpage": "https://hnrss.stateful.com/frontpage",
               "HN Best": "https://hnrss.stateful.com/best",
               "HN Newest": "https://hnrss.stateful.com/newest",
               "HN Ask": "https://hnrss.stateful.com/ask",

--- a/packages/widget-news/src/constants.ts
+++ b/packages/widget-news/src/constants.ts
@@ -5,7 +5,7 @@ export const FETCH_DATA_TIMEOUT = 10000
 export const DEFAULT_STATE: State = {
   news: [],
   isFetching: true,
-  channel: 'HN Best',
+  channel: 'HN Frontpage',
   error: null
 }
 export const DEFAULT_CONFIGURATION: Configuration = {


### PR DESCRIPTION
### Is your feature request related to a problem?

Turns out we are not providing the most important feed which is:

```
For just the posts that have appeared on the front page:

https://hnrss.org/frontpage
```

### Describe the solution you'd like.

Add `HN Frontpage` and make it default

### Describe alternatives you've considered.

_No response_

### Additional context

_No response_

### Code of Conduct

- [X] I agree to follow this project's Code of Conduct